### PR TITLE
Use `ReadOnlySpan` where known from const pointer in header file

### DIFF
--- a/MKL.NET.WrapperGenerator/WrapperGenerator.cs
+++ b/MKL.NET.WrapperGenerator/WrapperGenerator.cs
@@ -183,7 +183,7 @@ public class WrapperGenerator : ISourceGenerator
         {
             if (member is MethodDeclarationSyntax mds)
             {
-                // Array version
+                // Array version, ignore [In]
                 var arrayParams = TransformParameters(mds,
                 originalParam => originalParam.Type is PointerTypeSyntax pts
                     ? originalParam
@@ -194,20 +194,38 @@ public class WrapperGenerator : ISourceGenerator
                                 SyntaxFactory.List(new[] { SyntaxFactory.ArrayRankSpecifier() })
                             )
                         .WithTrailingTrivia(SyntaxFactory.Whitespace(" ")))
+                        .WithAttributeLists(SyntaxFactory.List<AttributeListSyntax>())
                     : null);
 
-                // Span version
+                // Span version, use [In] on pointer to mark possible read-only spans
+                var inAttribute = semantics.Compilation.GetTypeByMetadataName(typeof(System.Runtime.InteropServices.InAttribute).FullName);
                 var spanParams = TransformParameters(mds,
-                originalParam => originalParam.Type is PointerTypeSyntax pts
-                    ? originalParam
+                originalParam =>
+                {
+                    if (originalParam.Type is not PointerTypeSyntax pts)
+                    {
+                        return null;
+                    }
+
+                    var attributeTypes = originalParam.AttributeLists
+                        .SelectMany(al => al.Attributes)
+                        .Select(a => semantics.GetTypeInfo(a).Type)
+                        .ToImmutableHashSet();
+
+                    return originalParam
                         .WithType(
                             SyntaxFactory.GenericName
                             (
-                                SyntaxFactory.Identifier("global::System.Span"),
+                                SyntaxFactory.Identifier(
+                                    attributeTypes.Contains(inAttribute)
+                                    ? "global::System.ReadOnlySpan"
+                                    : "global::System.Span"
+                                ),
                                 SyntaxFactory.TypeArgumentList(SyntaxFactory.SeparatedList(new[] { pts.ElementType }))
                             )
                             .WithTrailingTrivia(SyntaxFactory.Whitespace(" ")))
-                    : null);
+                        .WithAttributeLists(SyntaxFactory.List<AttributeListSyntax>());
+                });
 
                 var lengthParam = GetLengthDropCandidate(mds);
                 WriterTransformedMethod(mds, nativeCds, arrayParams, sb, AdditionalTransformation.None);

--- a/MKL.NET.WrapperGenerator/WrapperGenerator.cs
+++ b/MKL.NET.WrapperGenerator/WrapperGenerator.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -13,6 +14,8 @@ namespace MKLNET.WrapperGenerator;
 [Generator]
 public class WrapperGenerator : ISourceGenerator
 {
+    private static readonly string _version = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "na";
+
     public void Initialize(GeneratorInitializationContext context)
     {
         context.RegisterForSyntaxNotifications(() => new UnsafeClassSyntaxReceiver());
@@ -104,7 +107,7 @@ public class WrapperGenerator : ISourceGenerator
         }
 
         sb.Append("\t\t///<summary>Calls the MKL function <c>").Append(mds.Identifier.Text).AppendLine("</c> by pinning the given data during the computation.</summary>");
-        sb.AppendLine("\t\t[global::System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
+        sb.AppendLine("\t\t[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
         sb.Append("\t\tpublic static ")
             .Append(mds.ReturnType)
             .Append(' ')
@@ -172,7 +175,7 @@ public class WrapperGenerator : ISourceGenerator
 
         sb.Append("namespace ").Append(parentClassSymbol.ContainingNamespace).AppendLine();
         sb.AppendLine("{");
-        sb.AppendLine("\t[global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"MKL.NET\", \"1.0\")]");
+        sb.AppendLine($"\t[global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"MKL.NET\", \"{_version}\")]");
         sb.Append("\tpartial class ").AppendLine(parentClassSymbol.Name);
         sb.AppendLine("\t{");
 

--- a/MKL.NET/Blas.cs
+++ b/MKL.NET/Blas.cs
@@ -26,94 +26,94 @@ public static partial class Blas
     public unsafe static class Unsafe
     {
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_sdot")]
-        public static extern float dot(int N, float* X, int incX, float* Y, int incY);
+        public static extern float dot(int N, /* const */ [In] float* X, int incX, /* const */ [In] float* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_sdoti")]
-        public static extern float doti(int N, float* X, int* indx, float* Y);
+        public static extern float doti(int N, /* const */ [In] float* X, int* indx, /* const */ [In] float* Y);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_ddot")]
-        public static extern double dot(int N, double* X, int incX, double* Y, int incY);
+        public static extern double dot(int N, /* const */ [In] double* X, int incX, /* const */ [In] double* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_ddoti")]
-        public static extern double doti(int N, double* X, int* indx, double* Y);
+        public static extern double doti(int N, /* const */ [In] double* X, int* indx, /* const */ [In] double* Y);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dsdot")]
-        public static extern double sdot(int N, float* X, int incX, float* Y, int incY);
+        public static extern double sdot(int N, /* const */ [In] float* X, int incX, /* const */ [In] float* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_sdsdot")]
-        public static extern float sdot(int N, float sb, float* X, int incX, float* Y, int incY);
+        public static extern float sdot(int N, float sb, /* const */ [In] float* X, int incX, /* const */ [In] float* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_snrm2")]
-        public static extern float nrm2(int N, float* X, int incX);
+        public static extern float nrm2(int N, /* const */ [In] float* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_sasum")]
-        public static extern float asum(int N, float* X, int incX);
+        public static extern float asum(int N, /* const */ [In] float* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dnrm2")]
-        public static extern double nrm2(int N, double* X, int incX);
+        public static extern double nrm2(int N, /* const */ [In] double* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dasum")]
-        public static extern double asum(int N, double* X, int incX);
+        public static extern double asum(int N, /* const */ [In] double* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_isamax")]
-        public static extern int iamax(int N, float* X, int incX);
+        public static extern int iamax(int N, /* const */ [In] float* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_idamax")]
-        public static extern int iamax(int N, double* X, int incX);
+        public static extern int iamax(int N, /* const */ [In] double* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_isamin")]
-        public static extern int iamin(int N, float* X, int incX);
+        public static extern int iamin(int N, /* const */ [In] float* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_idamin")]
-        public static extern int iamin(int N, double* X, int incX);
+        public static extern int iamin(int N, /* const */ [In] double* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_sswap")]
         public static extern void swap(int N, float* X, int incX, float* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_scopy")]
-        public static extern void copy(int N, float* X, int incX, float* Y, int incY);
+        public static extern void copy(int N, /* const */ [In] float* X, int incX, float* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_saxpy")]
-        public static extern void axpy(int N, float a, float* X, int incX, float* Y, int incY);
+        public static extern void axpy(int N, float a, /* const */ [In] float* X, int incX, float* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_saxpby")]
-        public static extern void axpby(int N, float alpha, float* X, int incX, float beta, float* Y, int incY);
+        public static extern void axpby(int N, float alpha, /* const */ [In] float* X, int incX, float beta, float* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_saxpyi")]
-        public static extern void axpyi(int N, float alpha, float* X, int* indx, float* Y);
+        public static extern void axpyi(int N, float alpha, /* const */ [In] float* X, int* indx, float* Y);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_sgthr")]
-        public static extern void gthr(int N, float* Y, float* X, int* indx);
+        public static extern void gthr(int N, /* const */ [In] float* Y, float* X, int* indx);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_sgthrz")]
         public static extern void gthrz(int N, float* Y, float* X, int* indx);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_ssctr")]
-        public static extern void sctr(int N, float* X, int* indx, float* Y);
+        public static extern void sctr(int N, /* const */ [In] float* X, int* indx, float* Y);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dswap")]
         public static extern void swap(int N, double* X, int incX, double* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dcopy")]
-        public static extern void copy(int N, double* X, int incX, double* Y, int incY);
+        public static extern void copy(int N, /* const */ [In] double* X, int incX, double* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_daxpy")]
-        public static extern void axpy(int N, double a, double* X, int incX, double* Y, int incY);
+        public static extern void axpy(int N, double a, /* const */ [In] double* X, int incX, double* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_daxpby")]
-        public static extern void axpby(int N, double alpha, double* X, int incX, double beta, double* Y, int incY);
+        public static extern void axpby(int N, double alpha, /* const */ [In] double* X, int incX, double beta, double* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_daxpyi")]
-        public static extern void axpyi(int N, double alpha, double* X, int* indx, double* Y);
+        public static extern void axpyi(int N, double alpha, /* const */ [In] double* X, int* indx, double* Y);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dgthr")]
-        public static extern void gthr(int N, double* Y, double* X, int* indx);
+        public static extern void gthr(int N, /* const */ [In] double* Y, double* X, int* indx);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dgthrz")]
         public static extern void gthrz(int N, double* Y, double* X, int* indx);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dsctr")]
-        public static extern void sctr(int N, double* X, int* indx, double* Y);
+        public static extern void sctr(int N, /* const */ [In] double* X, int* indx, double* Y);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_srotmg")]
         public static extern void rotmg(ref float d1, ref float d2, ref float x1, float y1, float* param);
@@ -148,283 +148,283 @@ public static partial class Blas
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_sgemv")]
         public static extern void gemv(Layout Layout,
                     Trans TransA, int M, int N,
-                    float alpha, float* A, int lda,
-                    float* X, int incX, float beta,
+                    float alpha, /* const */ [In] float* A, int lda,
+                     /* const */ [In] float* X, int incX, float beta,
                     float* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_sgbmv")]
         public static extern void gbmv(Layout Layout,
                     Trans TransA, int M, int N,
                     int KL, int KU, float alpha,
-                    float* A, int lda, float* X,
+                     /* const */ [In] float* A, int lda, /* const */ [In] float* X,
                     int incX, float beta, float* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_strmv")]
         public static extern void trmv(Layout Layout, UpLo UPLO,
                     Trans TransA, Diag Diag,
-                    int N, float* A, int lda,
+                    int N, /* const */ [In] float* A, int lda,
                     float* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_stbmv")]
         public static extern void tbmv(Layout Layout, UpLo UPLO,
                     Trans TransA, Diag Diag,
-                    int N, int K, float* A, int lda,
+                    int N, int K, /* const */ [In] float* A, int lda,
                     float* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_stpmv")]
         public static extern void tpmv(Layout Layout, UpLo UPLO,
                     Trans TransA, Diag Diag,
-                    int N, float* Ap, float* X, int incX);
+                    int N, /* const */ [In] float* Ap, float* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_strsv")]
         public static extern void trsv(Layout Layout, UpLo UPLO,
                     Trans TransA, Diag Diag,
-                    int N, float* A, int lda, float* X,
+                    int N, /* const */ [In] float* A, int lda, float* X,
                     int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_stbsv")]
         public static extern void tbsv(Layout Layout, UpLo UPLO,
                     Trans TransA, Diag Diag,
-                    int N, int K, float* A, int lda,
+                    int N, int K, /* const */ [In] float* A, int lda,
                     float* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_stpsv")]
         public static extern void tpsv(Layout Layout, UpLo UPLO,
                     Trans TransA, Diag Diag,
-                    int N, float* Ap, float* X, int incX);
+                    int N, /* const */ [In] float* Ap, float* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dgemv")]
         public static extern void gemv(Layout Layout,
                     Trans TransA, int M, int N,
-                    double alpha, double* A, int lda,
-                    double* X, int incX, double beta,
+                    double alpha, /* const */ [In] double* A, int lda,
+                     /* const */ [In] double* X, int incX, double beta,
                     double* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dgbmv")]
         public static extern void gbmv(Layout Layout,
                     Trans TransA, int M, int N,
                     int KL, int KU, double alpha,
-                    double* A, int lda, double* X,
+                     /* const */ [In] double* A, int lda, /* const */ [In] double* X,
                     int incX, double beta, double* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dtrmv")]
         public static extern void trmv(Layout Layout, UpLo UPLO,
                     Trans TransA, Diag Diag,
-                    int N, double* A, int lda,
+                    int N, /* const */ [In] double* A, int lda,
                     double* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dtbmv")]
         public static extern void tbmv(Layout Layout, UpLo UPLO,
                     Trans TransA, Diag Diag,
-                    int N, int K, double* A, int lda,
+                    int N, int K, /* const */ [In] double* A, int lda,
                     double* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dtpmv")]
         public static extern void tpmv(Layout Layout, UpLo UPLO,
                     Trans TransA, Diag Diag,
-                    int N, double* Ap, double* X, int incX);
+                    int N, /* const */ [In] double* Ap, double* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dtrsv")]
         public static extern void trsv(Layout Layout, UpLo UPLO,
                     Trans TransA, Diag Diag,
-                    int N, double* A, int lda, double* X,
+                    int N, /* const */ [In] double* A, int lda, double* X,
                     int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dtbsv")]
         public static extern void tbsv(Layout Layout, UpLo UPLO,
                     Trans TransA, Diag Diag,
-                    int N, int K, double* A, int lda,
+                    int N, int K, /* const */ [In] double* A, int lda,
                     double* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dtpsv")]
         public static extern void tpsv(Layout Layout, UpLo UPLO,
                     Trans TransA, Diag Diag,
-                    int N, double* Ap, double* X, int incX);
+                    int N, /* const */ [In] double* Ap, double* X, int incX);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_ssymv")]
         public static extern void symv(Layout Layout, UpLo UPLO,
-                    int N, float alpha, float* A,
-                    int lda, float* X, int incX,
+                    int N, float alpha, /* const */ [In] float* A,
+                    int lda, /* const */ [In] float* X, int incX,
                     float beta, float* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_ssbmv")]
         public static extern void sbmv(Layout Layout, UpLo UPLO,
-                    int N, int K, float alpha, float* A,
-                    int lda, float* X, int incX,
+                    int N, int K, float alpha, /* const */ [In] float* A,
+                    int lda, /* const */ [In] float* X, int incX,
                     float beta, float* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_sspmv")]
         public static extern void spmv(Layout Layout, UpLo UPLO,
-                    int N, float alpha, float* Ap,
-                    float* X, int incX,
+                    int N, float alpha, /* const */ [In] float* Ap,
+                     /* const */ [In] float* X, int incX,
                     float beta, float* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_sger")]
         public static extern void ger(Layout Layout, int M, int N,
-                    float alpha, float* X, int incX,
-                    float* Y, int incY, float* A, int lda);
+                    float alpha, /* const */ [In] float* X, int incX,
+                     /* const */ [In] float* Y, int incY, float* A, int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_ssyr")]
         public static extern void syr(Layout Layout, UpLo UPLO,
-                    int N, float alpha, float* X,
+                    int N, float alpha, /* const */ [In] float* X,
                     int incX, float* A, int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_sspr")]
         public static extern void spr(Layout Layout, UpLo UPLO,
-                    int N, float alpha, float* X,
+                    int N, float alpha, /* const */ [In] float* X,
                     int incX, float* Ap);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_ssyr2")]
         public static extern void syr2(Layout Layout, UpLo UPLO,
-                    int N, float alpha, float* X,
-                    int incX, float* Y, int incY, float* A,
+                    int N, float alpha, /* const */ [In] float* X,
+                    int incX, /* const */ [In] float* Y, int incY, float* A,
                     int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_sspr2")]
         public static extern void spr2(Layout Layout, UpLo UPLO,
-                    int N, float alpha, float* X,
-                    int incX, float* Y, int incY, float* A);
+                    int N, float alpha, /* const */ [In] float* X,
+                    int incX, /* const */ [In] float* Y, int incY, float* A);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dsymv")]
         public static extern void symv(Layout Layout, UpLo UPLO,
-                    int N, double alpha, double* A,
-                    int lda, double* X, int incX,
+                    int N, double alpha, /* const */ [In] double* A,
+                    int lda, /* const */ [In] double* X, int incX,
                     double beta, double* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dsbmv")]
         public static extern void sbmv(Layout Layout, UpLo UPLO,
-                    int N, int K, double alpha, double* A,
-                    int lda, double* X, int incX,
+                    int N, int K, double alpha, /* const */ [In] double* A,
+                    int lda, /* const */ [In] double* X, int incX,
                     double beta, double* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dspmv")]
         public static extern void spmv(Layout Layout, UpLo UPLO,
-                    int N, double alpha, double* Ap,
-                    double* X, int incX,
+                    int N, double alpha, /* const */ [In] double* Ap,
+                     /* const */ [In] double* X, int incX,
                     double beta, double* Y, int incY);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dger")]
         public static extern void ger(Layout Layout, int M, int N,
-                    double alpha, double* X, int incX,
-                    double* Y, int incY, double* A, int lda);
+                    double alpha, /* const */ [In] double* X, int incX,
+                     /* const */ [In] double* Y, int incY, double* A, int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dsyr")]
         public static extern void syr(Layout Layout, UpLo UPLO,
-                        int N, double alpha, double* X,
+                        int N, double alpha, /* const */ [In] double* X,
                         int incX, double* A, int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dspr")]
         public static extern void spr(Layout Layout, UpLo UPLO,
-                    int N, double alpha, double* X,
+                    int N, double alpha, /* const */ [In] double* X,
                     int incX, double* Ap);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dsyr2")]
         public static extern void syr2(Layout Layout, UpLo UPLO,
-                    int N, double alpha, double* X,
-                    int incX, double* Y, int incY, double* A,
+                    int N, double alpha, /* const */ [In] double* X,
+                    int incX, /* const */ [In] double* Y, int incY, double* A,
                     int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dspr2")]
         public static extern void spr2(Layout Layout, UpLo UPLO,
-                    int N, double alpha, double* X,
-                    int incX, double* Y, int incY, double* A);
+                    int N, double alpha, /* const */ [In] double* X,
+                    int incX, /* const */ [In] double* Y, int incY, double* A);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_sgemm")]
         public static extern void gemm(Layout Layout, Trans TransA,
                     Trans TransB, int M, int N,
-                    int K, float alpha, float* A,
-                    int lda, float* B, int ldb,
+                    int K, float alpha, /* const */ [In] float* A,
+                    int lda, /* const */ [In] float* B, int ldb,
                     float beta, float* C, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_sgemmt")]
         public static extern void gemmt(Layout Layout, UpLo UPLO,
                     Trans TransA, Trans TransB,
                     int N, int K,
-                    float alpha, float* A, int lda,
-                    float* B, int ldb, float beta,
+                    float alpha, /* const */ [In] float* A, int lda,
+                     /* const */ [In] float* B, int ldb, float beta,
                     float* C, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_ssymm")]
         public static extern void symm(Layout Layout, Side Side,
                     UpLo UPLO, int M, int N,
-                    float alpha, float* A, int lda,
-                    float* B, int ldb, float beta,
+                    float alpha, /* const */ [In] float* A, int lda,
+                     /* const */ [In] float* B, int ldb, float beta,
                     float* C, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_ssyrk")]
         public static extern void syrk(Layout Layout, UpLo UPLO,
                     Trans Trans, int N, int K,
-                    float alpha, float* A, int lda,
+                    float alpha, /* const */ [In] float* A, int lda,
                     float beta, float* C, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_ssyr2k")]
         public static extern void syr2k(Layout Layout, UpLo UPLO,
                     Trans Trans, int N, int K,
-                    float alpha, float* A, int lda,
-                    float* B, int ldb, float beta,
+                    float alpha, /* const */ [In] float* A, int lda,
+                     /* const */ [In] float* B, int ldb, float beta,
                     float* C, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_strmm")]
         public static extern void trmm(Layout Layout, Side Side,
                     UpLo UPLO, Trans TransA,
                     Diag Diag, int M, int N,
-                    float alpha, float* A, int lda,
+                    float alpha, /* const */ [In] float* A, int lda,
                     float* B, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_strsm")]
         public static extern void trsm(Layout Layout, Side Side,
                     UpLo UPLO, Trans TransA,
                     Diag Diag, int M, int N,
-                    float alpha, float* A, int lda,
+                    float alpha, /* const */ [In] float* A, int lda,
                     float* B, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dgemm")]
         public static extern void gemm(Layout Layout, Trans TransA,
                     Trans TransB, int M, int N,
-                    int K, double alpha, double* A,
-                    int lda, double* B, int ldb,
+                    int K, double alpha, /* const */ [In] double* A,
+                    int lda, /* const */ [In] double* B, int ldb,
                     double beta, double* C, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dgemmt")]
         public static extern void gemmt(Layout Layout, UpLo UPLO,
                     Trans TransA, Trans TransB,
                     int N, int K,
-                    double alpha, double* A, int lda,
-                    double* B, int ldb, double beta,
+                    double alpha, /* const */ [In] double* A, int lda,
+                     /* const */ [In] double* B, int ldb, double beta,
                     double* C, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dsymm")]
         public static extern void symm(Layout Layout, Side Side,
                     UpLo UPLO, int M, int N,
-                    double alpha, double* A, int lda,
-                    double* B, int ldb, double beta,
+                    double alpha, /* const */ [In] double* A, int lda,
+                     /* const */ [In] double* B, int ldb, double beta,
                     double* C, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dsyrk")]
         public static extern void syrk(Layout Layout, UpLo UPLO,
                     Trans Trans, int N, int K,
-                    double alpha, double* A, int lda,
+                    double alpha, /* const */ [In] double* A, int lda,
                     double beta, double* C, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dsyr2k")]
         public static extern void syr2k(Layout Layout, UpLo UPLO,
                     Trans Trans, int N, int K,
-                    double alpha, double* A, int lda,
-                    double* B, int ldb, double beta,
+                    double alpha, /* const */ [In] double* A, int lda,
+                     /* const */ [In] double* B, int ldb, double beta,
                     double* C, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dtrmm")]
         public static extern void trmm(Layout Layout, Side Side,
                     UpLo UPLO, Trans TransA,
                     Diag Diag, int M, int N,
-                    double alpha, double* A, int lda,
+                    double alpha, /* const */ [In] double* A, int lda,
                     double* B, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "cblas_dtrsm")]
         public static extern void trsm(Layout Layout, Side Side,
                     UpLo UPLO, Trans TransA,
                     Diag Diag, int M, int N,
-                    double alpha, double* A, int lda,
+                    double alpha, /* const */ [In] double* A, int lda,
                     double* B, int ldb);
     }
 

--- a/MKL.NET/Feast.cs
+++ b/MKL.NET/Feast.cs
@@ -26,9 +26,9 @@ public static partial class Feast
         public static extern void init(int* fpm);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "dfeast_syev")]
-        public static extern void syev(ref char uplo, ref int n, double* a, ref int lda, int* fpm, ref double epsout, ref int loop, ref double emin, ref double emax, ref int m0, double* e, double* x, ref int m, double* res, ref int info);
+        public static extern void syev(ref char uplo, ref int n, /* const */ [In] double* a, ref int lda, int* fpm, ref double epsout, ref int loop, ref double emin, ref double emax, ref int m0, double* e, double* x, ref int m, double* res, ref int info);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "sfeast_syev")]
-        public static extern void syev(ref char uplo, ref int n, float* a, ref int lda, int* fpm, ref float epsout, ref int loop, ref float emin, ref float emax, ref int m0, float* e, float* x, ref int m, float* res, ref int info);
+        public static extern void syev(ref char uplo, ref int n, /* const */ [In] float* a, ref int lda, int* fpm, ref float epsout, ref int loop, ref float emin, ref float emax, ref int m0, float* e, float* x, ref int m, float* res, ref int info);
     }
 }

--- a/MKL.NET/Lapack.cs
+++ b/MKL.NET/Lapack.cs
@@ -48,61 +48,61 @@ public static partial class Lapack
     {
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlange")]
         public static extern double lange(Layout layout, Norm norm, int m,
-            int n, double* a, int lda);
+            int n, /* const */ [In] double* a, int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlange_work")]
         public static extern double lange(Layout layout, Norm norm, int m,
-            int n, double* a, int lda,
+            int n, /* const */ [In] double* a, int lda,
             double* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlansy")]
         public static extern double lansy(Layout layout, Norm norm, UpLoChar uplo, int n,
-            double* a, int lda);
+            /* const */ [In] double* a, int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlansy_work")]
         public static extern double lansy(Layout layout, Norm norm, UpLoChar uplo,
-            int n, double* a, int lda,
+            int n, /* const */ [In] double* a, int lda,
             double* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlantr")]
         public static extern double lantr(Layout layout, Norm norm, UpLoChar uplo, DiagChar diag,
-            int m, int n, double* a,
+            int m, int n, /* const */ [In] double* a,
             int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlantr_work")]
         public static extern double lantr(Layout layout, Norm norm, UpLoChar uplo,
             DiagChar diag, int m, int n,
-            double* a, int lda, double* work);
+            /* const */ [In] double* a, int lda, double* work);
 
         
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slange")]
         public static extern float lange(Layout layout, Norm norm, int m,
-            int n, float* a, int lda);
+            int n, /* const */ [In] float* a, int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slange_work")]
         public static extern float lange(Layout layout, Norm norm, int m,
-            int n, float* a, int lda,
+            int n, /* const */ [In] float* a, int lda,
             float* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slansy")]
         public static extern float lansy(Layout layout, Norm norm, UpLoChar uplo, int n,
-            float* a, int lda);
+            /* const */ [In] float* a, int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slansy_work")]
         public static extern float lansy(Layout layout, Norm norm, UpLoChar uplo,
-            int n, float* a, int lda,
+            int n, /* const */ [In] float* a, int lda,
             float* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slantr")]
         public static extern float lantr(Layout layout, Norm norm, UpLoChar uplo, DiagChar diag,
-            int m, int n, float* a,
+            int m, int n, /* const */ [In] float* a,
             int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slantr_work")]
         public static extern float lantr(Layout layout, Norm norm, UpLoChar uplo,
             DiagChar diag, int m, int n,
-            float* a, int lda, float* work);
+            /* const */ [In] float* a, int lda, float* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dbbcsd")]
         public static extern int bbcsd(Layout layout, char jobu1, char jobu2,
@@ -172,7 +172,7 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ddisna")]
         public static extern int disna(char job, int m, int n,
-            double* d, double* sep);
+            /* const */ [In] double* d, double* sep);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgbbrd")]
         public static extern int gbbrd(Layout layout, char vect, int m,
@@ -192,43 +192,43 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgbcon")]
         public static extern int gbcon(Layout layout, Norm norm, int n,
-            int kl, int ku, double* ab,
+            int kl, int ku, /* const */ [In] double* ab,
             int ldab, int* ipiv,
             double anorm, double* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgbcon_work")]
         public static extern int gbcon(Layout layout, Norm norm, int n,
-            int kl, int ku, double* ab,
+            int kl, int ku, /* const */ [In] double* ab,
             int ldab, int* ipiv,
             double anorm, double* rcond, double* work,
             int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgbequ")]
         public static extern int gbequ(Layout layout, int m, int n,
-            int kl, int ku, double* ab,
+            int kl, int ku, /* const */ [In] double* ab,
             int ldab, double* r, double* c,
             double* rowcnd, double* colcnd, double* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgbequb")]
         public static extern int gbequb(Layout layout, int m, int n,
-            int kl, int ku, double* ab,
+            int kl, int ku, /* const */ [In] double* ab,
             int ldab, double* r, double* c,
             double* rowcnd, double* colcnd, double* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgbrfs")]
         public static extern int gbrfs(Layout layout, TransChar trans, int n,
             int kl, int ku, int nrhs,
-            double* ab, int ldab, double* afb,
+            /* const */ [In] double* ab, int ldab, /* const */ [In] double* afb,
             int ldafb, int* ipiv,
-            double* b, int ldb, double* x,
+            /* const */ [In] double* b, int ldb, double* x,
             int ldx, double* ferr, double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgbrfs_work")]
         public static extern int gbrfs(Layout layout, TransChar trans, int n,
             int kl, int ku, int nrhs,
-            double* ab, int ldab,
-            double* afb, int ldafb,
-            int* ipiv, double* b,
+            /* const */ [In] double* ab, int ldab,
+            /* const */ [In] double* afb, int ldafb,
+            int* ipiv, /* const */ [In] double* b,
             int ldb, double* x, int ldx,
             double* ferr, double* berr, double* work,
             int* iwork);
@@ -236,10 +236,10 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgbrfsx")]
         public static extern int gbrfsx(Layout layout, TransChar trans, char equed,
             int n, int kl, int ku,
-            int nrhs, double* ab, int ldab,
-            double* afb, int ldafb,
-            int* ipiv, double* r,
-            double* c, double* b, int ldb,
+            int nrhs, /* const */ [In] double* ab, int ldab,
+            /* const */ [In] double* afb, int ldafb,
+            int* ipiv, /* const */ [In] double* r,
+            /* const */ [In] double* c, /* const */ [In] double* b, int ldb,
             double* x, int ldx, double* rcond,
             double* berr, int n_err_bnds,
             double* err_bnds_norm, double* err_bnds_comp,
@@ -248,11 +248,11 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgbrfsx_work")]
         public static extern int gbrfsx(Layout layout, TransChar trans, char equed,
             int n, int kl, int ku,
-            int nrhs, double* ab,
-            int ldab, double* afb,
+            int nrhs, /* const */ [In] double* ab,
+            int ldab, /* const */ [In] double* afb,
             int ldafb, int* ipiv,
-            double* r, double* c,
-            double* b, int ldb, double* x,
+            /* const */ [In] double* r, /* const */ [In] double* c,
+            /* const */ [In] double* b, int ldb, double* x,
             int ldx, double* rcond, double* berr,
             int n_err_bnds, double* err_bnds_norm,
             double* err_bnds_comp, int nparams,
@@ -319,12 +319,12 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgbtrs")]
         public static extern int gbtrs(Layout layout, TransChar trans, int n,
             int kl, int ku, int nrhs,
-            double* ab, int ldab,
+            /* const */ [In] double* ab, int ldab,
             int* ipiv, double* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgebak")]
         public static extern int gebak(Layout layout, char job, char side, int n,
-            int ilo, int ihi, double* scale,
+            int ilo, int ihi, /* const */ [In] double* scale,
             int m, double* v, int ldv);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgebal")]
@@ -345,23 +345,23 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgecon")]
         public static extern int gecon(Layout layout, Norm norm, int n,
-            double* a, int lda, double anorm,
+            /* const */ [In] double* a, int lda, double anorm,
             double* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgecon_work")]
         public static extern int gecon(Layout layout, Norm norm, int n,
-            double* a, int lda, double anorm,
+            /* const */ [In] double* a, int lda, double anorm,
             double* rcond, double* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgeequ")]
         public static extern int geequ(Layout layout, int m, int n,
-            double* a, int lda, double* r,
+            /* const */ [In] double* a, int lda, double* r,
             double* c, double* rowcnd, double* colcnd,
             double* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgeequb")]
         public static extern int geequb(Layout layout, int m, int n,
-            double* a, int lda, double* r,
+            /* const */ [In] double* a, int lda, double* r,
             double* c, double* rowcnd, double* colcnd,
             double* amax);
 
@@ -493,15 +493,15 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgemqrt")]
         public static extern int gemqrt(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            int nb, double* v, int ldv,
-            double* t, int ldt, double* c,
+            int nb, /* const */ [In] double* v, int ldv,
+            /* const */ [In] double* t, int ldt, double* c,
             int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgemqrt_work")]
         public static extern int gemqrt(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            int nb, double* v, int ldv,
-            double* t, int ldt, double* c,
+            int nb, /* const */ [In] double* v, int ldv,
+            /* const */ [In] double* t, int ldt, double* c,
             int ldc, double* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgeqlf")]
@@ -582,27 +582,27 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgerfs")]
         public static extern int gerfs(Layout layout, TransChar trans, int n,
-            int nrhs, double* a, int lda,
-            double* af, int ldaf,
-            int* ipiv, double* b,
+            int nrhs, /* const */ [In] double* a, int lda,
+            /* const */ [In] double* af, int ldaf,
+            int* ipiv, /* const */ [In] double* b,
             int ldb, double* x, int ldx,
             double* ferr, double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgerfs_work")]
         public static extern int gerfs(Layout layout, TransChar trans, int n,
-            int nrhs, double* a,
-            int lda, double* af,
+            int nrhs, /* const */ [In] double* a,
+            int lda, /* const */ [In] double* af,
             int ldaf, int* ipiv,
-            double* b, int ldb, double* x,
+            /* const */ [In] double* b, int ldb, double* x,
             int ldx, double* ferr, double* berr,
             double* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgerfsx")]
         public static extern int gerfsx(Layout layout, TransChar trans, char equed,
-            int n, int nrhs, double* a,
-            int lda, double* af, int ldaf,
-            int* ipiv, double* r,
-            double* c, double* b, int ldb,
+            int n, int nrhs, /* const */ [In] double* a,
+            int lda, /* const */ [In] double* af, int ldaf,
+            int* ipiv, /* const */ [In] double* r,
+            /* const */ [In] double* c, /* const */ [In] double* b, int ldb,
             double* x, int ldx, double* rcond,
             double* berr, int n_err_bnds,
             double* err_bnds_norm, double* err_bnds_comp,
@@ -610,11 +610,11 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgerfsx_work")]
         public static extern int gerfsx(Layout layout, TransChar trans, char equed,
-            int n, int nrhs, double* a,
-            int lda, double* af,
+            int n, int nrhs, /* const */ [In] double* a,
+            int lda, /* const */ [In] double* af,
             int ldaf, int* ipiv,
-            double* r, double* c,
-            double* b, int ldb, double* x,
+            /* const */ [In] double* r, /* const */ [In] double* c,
+            /* const */ [In] double* b, int ldb, double* x,
             int ldx, double* rcond, double* berr,
             int n_err_bnds, double* err_bnds_norm,
             double* err_bnds_comp, int nparams,
@@ -757,13 +757,13 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgetrs")]
         public static extern int getrs(Layout layout, TransChar trans, int n,
-            int nrhs, double* a, int lda,
+            int nrhs, /* const */ [In] double* a, int lda,
             int* ipiv, double* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dggbak")]
         public static extern int ggbak(Layout layout, char job, char side, int n,
-            int ilo, int ihi, double* lscale,
-            double* rscale, int m, double* v,
+            int ilo, int ihi, /* const */ [In] double* lscale,
+            /* const */ [In] double* rscale, int m, double* v,
             int ldv);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dggbal")]
@@ -979,33 +979,33 @@ public static partial class Lapack
             int* iwork, double* tau, double* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgtcon")]
-        public static extern int gtcon(Norm norm, int n, double* dl,
-            double* d, double* du, double* du2,
+        public static extern int gtcon(Norm norm, int n, /* const */ [In] double* dl,
+            /* const */ [In] double* d, /* const */ [In] double* du, /* const */ [In] double* du2,
             int* ipiv, double anorm, double* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgtcon_work")]
-        public static extern int gtcon(Norm norm, int n, double* dl,
-            double* d, double* du,
-            double* du2, int* ipiv,
+        public static extern int gtcon(Norm norm, int n, /* const */ [In] double* dl,
+            /* const */ [In] double* d, /* const */ [In] double* du,
+            /* const */ [In] double* du2, int* ipiv,
             double anorm, double* rcond, double* work,
             int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgtrfs")]
         public static extern int gtrfs(Layout layout, TransChar trans, int n,
-            int nrhs, double* dl, double* d,
-            double* du, double* dlf,
-            double* df, double* duf,
-            double* du2, int* ipiv,
-            double* b, int ldb, double* x,
+            int nrhs, /* const */ [In] double* dl, /* const */ [In] double* d,
+            /* const */ [In] double* du, /* const */ [In] double* dlf,
+            /* const */ [In] double* df, /* const */ [In] double* duf,
+            /* const */ [In] double* du2, int* ipiv,
+            /* const */ [In] double* b, int ldb, double* x,
             int ldx, double* ferr, double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgtrfs_work")]
         public static extern int gtrfs(Layout layout, TransChar trans, int n,
-            int nrhs, double* dl,
-            double* d, double* du,
-            double* dlf, double* df,
-            double* duf, double* du2,
-            int* ipiv, double* b,
+            int nrhs, /* const */ [In] double* dl,
+            /* const */ [In] double* d, /* const */ [In] double* du,
+            /* const */ [In] double* dlf, /* const */ [In] double* df,
+            /* const */ [In] double* duf, /* const */ [In] double* du2,
+            int* ipiv, /* const */ [In] double* b,
             int ldb, double* x, int ldx,
             double* ferr, double* berr, double* work,
             int* iwork);
@@ -1017,19 +1017,19 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgtsvx")]
         public static extern int gtsvx(Layout layout, char fact, TransChar trans,
-            int n, int nrhs, double* dl,
-            double* d, double* du, double* dlf,
+            int n, int nrhs, /* const */ [In] double* dl,
+            /* const */ [In] double* d, /* const */ [In] double* du, double* dlf,
             double* df, double* duf, double* du2,
-            int* ipiv, double* b, int ldb,
+            int* ipiv, /* const */ [In] double* b, int ldb,
             double* x, int ldx, double* rcond,
             double* ferr, double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgtsvx_work")]
         public static extern int gtsvx(Layout layout, char fact, TransChar trans,
-            int n, int nrhs, double* dl,
-            double* d, double* du, double* dlf,
+            int n, int nrhs, /* const */ [In] double* dl,
+            /* const */ [In] double* d, /* const */ [In] double* du, double* dlf,
             double* df, double* duf, double* du2,
-            int* ipiv, double* b,
+            int* ipiv, /* const */ [In] double* b,
             int ldb, double* x, int ldx,
             double* rcond, double* ferr, double* berr,
             double* work, int* iwork);
@@ -1040,8 +1040,8 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgttrs")]
         public static extern int gttrs(Layout layout, TransChar trans, int n,
-            int nrhs, double* dl, double* d,
-            double* du, double* du2,
+            int nrhs, /* const */ [In] double* dl, /* const */ [In] double* d,
+            /* const */ [In] double* du, /* const */ [In] double* du2,
             int* ipiv, double* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dhgeqz")]
@@ -1064,8 +1064,8 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dhsein")]
         public static extern int hsein(Layout layout, char job, char eigsrc, char initv,
             int* select, int n,
-            double* h, int ldh, double* wr,
-            double* wi, double* vl, int ldvl,
+            /* const */ [In] double* h, int ldh, double* wr,
+            /* const */ [In] double* wi, double* vl, int ldvl,
             double* vr, int ldvr, int mm,
             int* m, int* ifaill,
             int* ifailr);
@@ -1073,8 +1073,8 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dhsein_work")]
         public static extern int hsein(Layout layout, char job, char eigsrc,
             char initv, int* select,
-            int n, double* h, int ldh,
-            double* wr, double* wi, double* vl,
+            int n, /* const */ [In] double* h, int ldh,
+            double* wr, /* const */ [In] double* wi, double* vl,
             int ldvl, double* vr, int ldvr,
             int mm, int* m, double* work,
             int* ifaill, int* ifailr);
@@ -1098,33 +1098,33 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlacpy")]
         public static extern int lacpy(Layout layout, UpLoChar uplo, int m,
-            int n, double* a, int lda,
+            int n, /* const */ [In] double* a, int lda,
             double* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlag2s")]
         public static extern int lag2s(Layout layout, int m, int n,
-            double* a, int lda, float* sa,
+            /* const */ [In] double* a, int lda, float* sa,
             int ldsa);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlagge")]
         public static extern int lagge(Layout layout, int m, int n,
-            int kl, int ku, double* d,
+            int kl, int ku, /* const */ [In] double* d,
             double* a, int lda, int* iseed);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlagge_work")]
         public static extern int lagge(Layout layout, int m, int n,
-            int kl, int ku, double* d,
+            int kl, int ku, /* const */ [In] double* d,
             double* a, int lda, int* iseed,
             double* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlagsy")]
         public static extern int lagsy(Layout layout, int n, int k,
-            double* d, double* a, int lda,
+            /* const */ [In] double* d, double* a, int lda,
             int* iseed);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlagsy_work")]
         public static extern int lagsy(Layout layout, int n, int k,
-            double* d, double* a, int lda,
+            /* const */ [In] double* d, double* a, int lda,
             int* iseed, double* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlapmr")]
@@ -1140,15 +1140,15 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlarfb")]
         public static extern int larfb(Layout layout, char side, TransChar trans, char direct,
             char storev, int m, int n,
-            int k, double* v, int ldv,
-            double* t, int ldt, double* c,
+            int k, /* const */ [In] double* v, int ldv,
+            /* const */ [In] double* t, int ldt, double* c,
             int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlarfb_work")]
         public static extern int larfb(Layout layout, char side, TransChar trans,
             char direct, char storev, int m,
-            int n, int k, double* v,
-            int ldv, double* t, int ldt,
+            int n, int k, /* const */ [In] double* v,
+            int ldv, /* const */ [In] double* t, int ldt,
             double* c, int ldc, double* work,
             int ldwork);
 
@@ -1158,13 +1158,13 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlarft")]
         public static extern int larft(Layout layout, char direct, char storev,
-            int n, int k, double* v,
-            int ldv, double* tau, double* t,
+            int n, int k, /* const */ [In] double* v,
+            int ldv, /* const */ [In] double* tau, double* t,
             int ldt);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlarfx")]
         public static extern int larfx(Layout layout, char side, int m,
-            int n, double* v, double tau, double* c,
+            int n, /* const */ [In] double* v, double tau, double* c,
             int ldc, double* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dlarnv")]
@@ -1219,23 +1219,23 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dopgtr")]
         public static extern int opgtr(Layout layout, UpLoChar uplo, int n,
-            double* ap, double* tau, double* q,
+            /* const */ [In] double* ap, /* const */ [In] double* tau, double* q,
             int ldq);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dopgtr_work")]
         public static extern int opgtr(Layout layout, UpLoChar uplo, int n,
-            double* ap, double* tau, double* q,
+            /* const */ [In] double* ap, /* const */ [In] double* tau, double* q,
             int ldq, double* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dopmtr")]
         public static extern int opmtr(Layout layout, char side, UpLoChar uplo, TransChar trans,
-            int m, int n, double* ap,
-            double* tau, double* c, int ldc);
+            int m, int n, /* const */ [In] double* ap,
+            /* const */ [In] double* tau, double* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dopmtr_work")]
         public static extern int opmtr(Layout layout, char side, UpLoChar uplo,
             TransChar trans, int m, int n,
-            double* ap, double* tau, double* c,
+            /* const */ [In] double* ap, /* const */ [In] double* tau, double* c,
             int ldc, double* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dorbdb")]
@@ -1306,7 +1306,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dorgbr_work")]
         public static extern int orgbr(Layout layout, char vect, int m,
             int n, int k, double* a,
-            int lda, double* tau, double* work,
+            int lda, /* const */ [In] double* tau, double* work,
             int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dorghr")]
@@ -1317,7 +1317,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dorghr_work")]
         public static extern int orghr(Layout layout, int n, int ilo,
             int ihi, double* a, int lda,
-            double* tau, double* work,
+            /* const */ [In] double* tau, double* work,
             int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dorglq")]
@@ -1328,7 +1328,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dorglq_work")]
         public static extern int orglq(Layout layout, int m, int n,
             int k, double* a, int lda,
-            double* tau, double* work,
+            /* const */ [In] double* tau, double* work,
             int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dorgql")]
@@ -1339,7 +1339,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dorgql_work")]
         public static extern int orgql(Layout layout, int m, int n,
             int k, double* a, int lda,
-            double* tau, double* work,
+            /* const */ [In] double* tau, double* work,
             int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dorgqr")]
@@ -1350,7 +1350,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dorgqr_work")]
         public static extern int orgqr(Layout layout, int m, int n,
             int k, double* a, int lda,
-            double* tau, double* work,
+            /* const */ [In] double* tau, double* work,
             int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dorgrq")]
@@ -1361,7 +1361,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dorgrq_work")]
         public static extern int orgrq(Layout layout, int m, int n,
             int k, double* a, int lda,
-            double* tau, double* work,
+            /* const */ [In] double* tau, double* work,
             int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dorgtr")]
@@ -1370,142 +1370,142 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dorgtr_work")]
         public static extern int orgtr(Layout layout, UpLoChar uplo, int n,
-            double* a, int lda, double* tau,
+            double* a, int lda, /* const */ [In] double* tau,
             double* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormbr")]
         public static extern int ormbr(Layout layout, char vect, char side, TransChar trans,
             int m, int n, int k,
-            double* a, int lda, double* tau,
+            /* const */ [In] double* a, int lda, /* const */ [In] double* tau,
             double* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormbr_work")]
         public static extern int ormbr(Layout layout, char vect, char side,
             TransChar trans, int m, int n,
-            int k, double* a, int lda,
-            double* tau, double* c, int ldc,
+            int k, /* const */ [In] double* a, int lda,
+            /* const */ [In] double* tau, double* c, int ldc,
             double* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormhr")]
         public static extern int ormhr(Layout layout, char side, TransChar trans,
             int m, int n, int ilo,
-            int ihi, double* a, int lda,
-            double* tau, double* c, int ldc);
+            int ihi, /* const */ [In] double* a, int lda,
+            /* const */ [In] double* tau, double* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormhr_work")]
         public static extern int ormhr(Layout layout, char side, TransChar trans,
             int m, int n, int ilo,
-            int ihi, double* a, int lda,
-            double* tau, double* c, int ldc,
+            int ihi, /* const */ [In] double* a, int lda,
+            /* const */ [In] double* tau, double* c, int ldc,
             double* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormlq")]
         public static extern int ormlq(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            double* a, int lda, double* tau,
+            /* const */ [In] double* a, int lda, /* const */ [In] double* tau,
             double* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormlq_work")]
         public static extern int ormlq(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            double* a, int lda,
-            double* tau, double* c, int ldc,
+            /* const */ [In] double* a, int lda,
+            /* const */ [In] double* tau, double* c, int ldc,
             double* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormql")]
         public static extern int ormql(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            double* a, int lda, double* tau,
+            /* const */ [In] double* a, int lda, /* const */ [In] double* tau,
             double* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormql_work")]
         public static extern int ormql(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            double* a, int lda,
-            double* tau, double* c, int ldc,
+            /* const */ [In] double* a, int lda,
+            /* const */ [In] double* tau, double* c, int ldc,
             double* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormqr")]
         public static extern int ormqr(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            double* a, int lda, double* tau,
+            /* const */ [In] double* a, int lda, /* const */ [In] double* tau,
             double* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormqr_work")]
         public static extern int ormqr(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            double* a, int lda,
-            double* tau, double* c, int ldc,
+            /* const */ [In] double* a, int lda,
+            /* const */ [In] double* tau, double* c, int ldc,
             double* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormrq")]
         public static extern int ormrq(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            double* a, int lda, double* tau,
+            /* const */ [In] double* a, int lda, /* const */ [In] double* tau,
             double* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormrq_work")]
         public static extern int ormrq(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            double* a, int lda,
-            double* tau, double* c, int ldc,
+            /* const */ [In] double* a, int lda,
+            /* const */ [In] double* tau, double* c, int ldc,
             double* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormrz")]
         public static extern int ormrz(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            int l, double* a, int lda,
-            double* tau, double* c, int ldc);
+            int l, /* const */ [In] double* a, int lda,
+            /* const */ [In] double* tau, double* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormrz_work")]
         public static extern int ormrz(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            int l, double* a, int lda,
-            double* tau, double* c, int ldc,
+            int l, /* const */ [In] double* a, int lda,
+            /* const */ [In] double* tau, double* c, int ldc,
             double* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormtr")]
         public static extern int ormtr(Layout layout, char side, UpLoChar uplo, TransChar trans,
-            int m, int n, double* a,
-            int lda, double* tau, double* c,
+            int m, int n, /* const */ [In] double* a,
+            int lda, /* const */ [In] double* tau, double* c,
             int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dormtr_work")]
         public static extern int ormtr(Layout layout, char side, UpLoChar uplo,
             TransChar trans, int m, int n,
-            double* a, int lda,
-            double* tau, double* c, int ldc,
+            /* const */ [In] double* a, int lda,
+            /* const */ [In] double* tau, double* c, int ldc,
             double* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpbcon")]
         public static extern int pbcon(Layout layout, UpLoChar uplo, int n,
-            int kd, double* ab, int ldab,
+            int kd, /* const */ [In] double* ab, int ldab,
             double anorm, double* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpbcon_work")]
         public static extern int pbcon(Layout layout, UpLoChar uplo, int n,
-            int kd, double* ab,
+            int kd, /* const */ [In] double* ab,
             int ldab, double anorm, double* rcond,
             double* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpbequ")]
         public static extern int pbequ(Layout layout, UpLoChar uplo, int n,
-            int kd, double* ab, int ldab,
+            int kd, /* const */ [In] double* ab, int ldab,
             double* s, double* scond, double* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpbrfs")]
         public static extern int pbrfs(Layout layout, UpLoChar uplo, int n,
-            int kd, int nrhs, double* ab,
-            int ldab, double* afb, int ldafb,
-            double* b, int ldb, double* x,
+            int kd, int nrhs, /* const */ [In] double* ab,
+            int ldab, /* const */ [In] double* afb, int ldafb,
+            /* const */ [In] double* b, int ldb, double* x,
             int ldx, double* ferr, double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpbrfs_work")]
         public static extern int pbrfs(Layout layout, UpLoChar uplo, int n,
             int kd, int nrhs,
-            double* ab, int ldab,
-            double* afb, int ldafb,
-            double* b, int ldb, double* x,
+            /* const */ [In] double* ab, int ldab,
+            /* const */ [In] double* afb, int ldafb,
+            /* const */ [In] double* b, int ldb, double* x,
             int ldx, double* ferr, double* berr,
             double* work, int* iwork);
 
@@ -1541,7 +1541,7 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpbtrs")]
         public static extern int pbtrs(Layout layout, UpLoChar uplo, int n,
-            int kd, int nrhs, double* ab,
+            int kd, int nrhs, /* const */ [In] double* ab,
             int ldab, double* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpftrf")]
@@ -1554,50 +1554,50 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpftrs")]
         public static extern int pftrs(Layout layout, TransChar transr, UpLoChar uplo,
-            int n, int nrhs, double* a,
+            int n, int nrhs, /* const */ [In] double* a,
             double* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpocon")]
         public static extern int pocon(Layout layout, UpLoChar uplo, int n,
-            double* a, int lda, double anorm,
+            /* const */ [In] double* a, int lda, double anorm,
             double* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpocon_work")]
         public static extern int pocon(Layout layout, UpLoChar uplo, int n,
-            double* a, int lda, double anorm,
+            /* const */ [In] double* a, int lda, double anorm,
             double* rcond, double* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpoequ")]
-        public static extern int poequ(Layout layout, int n, double* a,
+        public static extern int poequ(Layout layout, int n, /* const */ [In] double* a,
             int lda, double* s, double* scond,
             double* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpoequb")]
-        public static extern int poequb(Layout layout, int n, double* a,
+        public static extern int poequb(Layout layout, int n, /* const */ [In] double* a,
             int lda, double* s, double* scond,
             double* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dporfs")]
         public static extern int porfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* a, int lda,
-            double* af, int ldaf, double* b,
+            int nrhs, /* const */ [In] double* a, int lda,
+            /* const */ [In] double* af, int ldaf, /* const */ [In] double* b,
             int ldb, double* x, int ldx,
             double* ferr, double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dporfs_work")]
         public static extern int porfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* a,
-            int lda, double* af,
-            int ldaf, double* b,
+            int nrhs, /* const */ [In] double* a,
+            int lda, /* const */ [In] double* af,
+            int ldaf, /* const */ [In] double* b,
             int ldb, double* x, int ldx,
             double* ferr, double* berr, double* work,
             int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dporfsx")]
         public static extern int porfsx(Layout layout, UpLoChar uplo, char equed,
-            int n, int nrhs, double* a,
-            int lda, double* af, int ldaf,
-            double* s, double* b, int ldb,
+            int n, int nrhs, /* const */ [In] double* a,
+            int lda, /* const */ [In] double* af, int ldaf,
+            /* const */ [In] double* s, /* const */ [In] double* b, int ldb,
             double* x, int ldx, double* rcond,
             double* berr, int n_err_bnds,
             double* err_bnds_norm, double* err_bnds_comp,
@@ -1605,10 +1605,10 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dporfsx_work")]
         public static extern int porfsx(Layout layout, UpLoChar uplo, char equed,
-            int n, int nrhs, double* a,
-            int lda, double* af,
-            int ldaf, double* s,
-            double* b, int ldb, double* x,
+            int n, int nrhs, /* const */ [In] double* a,
+            int lda, /* const */ [In] double* af,
+            int ldaf, /* const */ [In] double* s,
+            /* const */ [In] double* b, int ldb, double* x,
             int ldx, double* rcond, double* berr,
             int n_err_bnds, double* err_bnds_norm,
             double* err_bnds_comp, int nparams,
@@ -1672,33 +1672,33 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpotrs")]
         public static extern int potrs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* a, int lda,
+            int nrhs, /* const */ [In] double* a, int lda,
             double* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dppcon")]
         public static extern int ppcon(Layout layout, UpLoChar uplo, int n,
-            double* ap, double anorm, double* rcond);
+            /* const */ [In] double* ap, double anorm, double* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dppcon_work")]
         public static extern int ppcon(Layout layout, UpLoChar uplo, int n,
-            double* ap, double anorm, double* rcond,
+            /* const */ [In] double* ap, double anorm, double* rcond,
             double* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dppequ")]
         public static extern int ppequ(Layout layout, UpLoChar uplo, int n,
-            double* ap, double* s, double* scond,
+            /* const */ [In] double* ap, double* s, double* scond,
             double* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpprfs")]
         public static extern int pprfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* ap, double* afp,
-            double* b, int ldb, double* x,
+            int nrhs, /* const */ [In] double* ap, /* const */ [In] double* afp,
+            /* const */ [In] double* b, int ldb, double* x,
             int ldx, double* ferr, double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpprfs_work")]
         public static extern int pprfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* ap,
-            double* afp, double* b,
+            int nrhs, /* const */ [In] double* ap,
+            /* const */ [In] double* afp, /* const */ [In] double* b,
             int ldb, double* x, int ldx,
             double* ferr, double* berr, double* work,
             int* iwork);
@@ -1733,7 +1733,7 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpptrs")]
         public static extern int pptrs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* ap, double* b,
+            int nrhs, /* const */ [In] double* ap, double* b,
             int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpstrf")]
@@ -1747,11 +1747,11 @@ public static partial class Lapack
             ref int rank, double tol, double* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dptcon")]
-        public static extern int ptcon(int n, double* d, double* e,
+        public static extern int ptcon(int n, /* const */ [In] double* d, /* const */ [In] double* e,
             double anorm, double* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dptcon_work")]
-        public static extern int ptcon(int n, double* d, double* e,
+        public static extern int ptcon(int n, /* const */ [In] double* d, /* const */ [In] double* e,
             double anorm, double* rcond, double* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpteqr")]
@@ -1765,16 +1765,16 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dptrfs")]
         public static extern int ptrfs(Layout layout, int n, int nrhs,
-            double* d, double* e, double* df,
-            double* ef, double* b, int ldb,
+            /* const */ [In] double* d, /* const */ [In] double* e, /* const */ [In] double* df,
+            /* const */ [In] double* ef, /* const */ [In] double* b, int ldb,
             double* x, int ldx, double* ferr,
             double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dptrfs_work")]
         public static extern int ptrfs(Layout layout, int n, int nrhs,
-            double* d, double* e,
-            double* df, double* ef,
-            double* b, int ldb, double* x,
+            /* const */ [In] double* d, /* const */ [In] double* e,
+            /* const */ [In] double* df, /* const */ [In] double* ef,
+            /* const */ [In] double* b, int ldb, double* x,
             int ldx, double* ferr, double* berr,
             double* work);
 
@@ -1784,16 +1784,16 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dptsvx")]
         public static extern int ptsvx(Layout layout, char fact, int n,
-            int nrhs, double* d, double* e,
-            double* df, double* ef, double* b,
+            int nrhs, /* const */ [In] double* d, /* const */ [In] double* e,
+            double* df, double* ef, /* const */ [In] double* b,
             int ldb, double* x, int ldx,
             double* rcond, double* ferr, double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dptsvx_work")]
         public static extern int ptsvx(Layout layout, char fact, int n,
-            int nrhs, double* d,
-            double* e, double* df, double* ef,
-            double* b, int ldb, double* x,
+            int nrhs, /* const */ [In] double* d,
+            /* const */ [In] double* e, double* df, double* ef,
+            /* const */ [In] double* b, int ldb, double* x,
             int ldx, double* rcond, double* ferr,
             double* berr, double* work);
 
@@ -1802,7 +1802,7 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dpttrs")]
         public static extern int pttrs(Layout layout, int n, int nrhs,
-            double* d, double* e, double* b,
+            /* const */ [In] double* d, /* const */ [In] double* e, double* b,
             int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsbev")]
@@ -1849,13 +1849,13 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsbgst")]
         public static extern int sbgst(Layout layout, char vect, UpLoChar uplo, int n,
             int ka, int kb, double* ab,
-            int ldab, double* bb, int ldbb,
+            int ldab, /* const */ [In] double* bb, int ldbb,
             double* x, int ldx);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsbgst_work")]
         public static extern int sbgst(Layout layout, char vect, UpLoChar uplo,
             int n, int ka, int kb,
-            double* ab, int ldab, double* bb,
+            double* ab, int ldab, /* const */ [In] double* bb,
             int ldbb, double* x, int ldx,
             double* work);
 
@@ -1920,7 +1920,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsfrk")]
         public static extern int sfrk(Layout layout, TransChar transr, UpLoChar uplo, TransChar trans,
             int n, int k, double alpha,
-            double* a, int lda, double beta,
+            /* const */ [In] double* a, int lda, double beta,
             double* c);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsgesv")]
@@ -1938,12 +1938,12 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dspcon")]
         public static extern int spcon(Layout layout, UpLoChar uplo, int n,
-            double* ap, int* ipiv,
+            /* const */ [In] double* ap, int* ipiv,
             double anorm, double* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dspcon_work")]
         public static extern int spcon(Layout layout, UpLoChar uplo, int n,
-            double* ap, int* ipiv,
+            /* const */ [In] double* ap, int* ipiv,
             double anorm, double* rcond, double* work,
             int* iwork);
 
@@ -2040,16 +2040,16 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsprfs")]
         public static extern int sprfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* ap, double* afp,
-            int* ipiv, double* b,
+            int nrhs, /* const */ [In] double* ap, /* const */ [In] double* afp,
+            int* ipiv, /* const */ [In] double* b,
             int ldb, double* x, int ldx,
             double* ferr, double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsprfs_work")]
         public static extern int sprfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* ap,
-            double* afp, int* ipiv,
-            double* b, int ldb, double* x,
+            int nrhs, /* const */ [In] double* ap,
+            /* const */ [In] double* afp, int* ipiv,
+            /* const */ [In] double* b, int ldb, double* x,
             int ldx, double* ferr, double* berr,
             double* work, int* iwork);
 
@@ -2060,15 +2060,15 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dspsvx")]
         public static extern int spsvx(Layout layout, char fact, UpLoChar uplo, int n,
-            int nrhs, double* ap, double* afp,
-            int* ipiv, double* b, int ldb,
+            int nrhs, /* const */ [In] double* ap, double* afp,
+            int* ipiv, /* const */ [In] double* b, int ldb,
             double* x, int ldx, double* rcond,
             double* ferr, double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dspsvx_work")]
         public static extern int spsvx(Layout layout, char fact, UpLoChar uplo,
-            int n, int nrhs, double* ap,
-            double* afp, int* ipiv, double* b,
+            int n, int nrhs, /* const */ [In] double* ap,
+            double* afp, int* ipiv, /* const */ [In] double* b,
             int ldb, double* x, int ldx,
             double* rcond, double* ferr, double* berr,
             double* work, int* iwork);
@@ -2092,20 +2092,20 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsptrs")]
         public static extern int sptrs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* ap,
+            int nrhs, /* const */ [In] double* ap,
             int* ipiv, double* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dstebz")]
         public static extern int stebz(char range, char order, int n, double vl,
             double vu, int il, int iu,
-            double abstol, double* d, double* e,
+            double abstol, /* const */ [In] double* d, /* const */ [In] double* e,
             int* m, int* nsplit, double* w,
             int* iblock, int* isplit);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dstebz_work")]
         public static extern int stebz(char range, char order, int n, double vl,
             double vu, int il, int iu,
-            double abstol, double* d, double* e,
+            double abstol, /* const */ [In] double* d, /* const */ [In] double* e,
             int* m, int* nsplit, double* w,
             int* iblock, int* isplit,
             double* work, int* iwork);
@@ -2137,14 +2137,14 @@ public static partial class Lapack
             int* iwork, int liwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dstein")]
-        public static extern int stein(Layout layout, int n, double* d,
-            double* e, int m, double* w,
+        public static extern int stein(Layout layout, int n, /* const */ [In] double* d,
+            /* const */ [In] double* e, int m, /* const */ [In] double* w,
             int* iblock, int* isplit,
             double* z, int ldz, int* ifailv);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dstein_work")]
-        public static extern int stein(Layout layout, int n, double* d,
-            double* e, int m, double* w,
+        public static extern int stein(Layout layout, int n, /* const */ [In] double* d,
+            /* const */ [In] double* e, int m, /* const */ [In] double* w,
             int* iblock,
             int* isplit, double* z,
             int ldz, double* work, int* iwork,
@@ -2232,12 +2232,12 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsycon")]
         public static extern int sycon(Layout layout, UpLoChar uplo, int n,
-            double* a, int lda,
+            /* const */ [In] double* a, int lda,
             int* ipiv, double anorm, double* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsycon_work")]
         public static extern int sycon(Layout layout, UpLoChar uplo, int n,
-            double* a, int lda,
+            /* const */ [In] double* a, int lda,
             int* ipiv, double anorm,
             double* rcond, double* work, int* iwork);
 
@@ -2248,12 +2248,12 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsyequb")]
         public static extern int syequb(Layout layout, UpLoChar uplo, int n,
-            double* a, int lda, double* s,
+            /* const */ [In] double* a, int lda, double* s,
             double* scond, double* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsyequb_work")]
         public static extern int syequb(Layout layout, UpLoChar uplo, int n,
-            double* a, int lda, double* s,
+            /* const */ [In] double* a, int lda, double* s,
             double* scond, double* amax, double* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsyev")]
@@ -2311,7 +2311,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsygst")]
         public static extern int sygst(Layout layout, int itype, UpLoChar uplo,
             int n, double* a, int lda,
-            double* b, int ldb);
+            /* const */ [In] double* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsygv")]
         public static extern int sygv(Layout layout, int itype, char jobz,
@@ -2356,27 +2356,27 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsyrfs")]
         public static extern int syrfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* a, int lda,
-            double* af, int ldaf,
-            int* ipiv, double* b,
+            int nrhs, /* const */ [In] double* a, int lda,
+            /* const */ [In] double* af, int ldaf,
+            int* ipiv, /* const */ [In] double* b,
             int ldb, double* x, int ldx,
             double* ferr, double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsyrfs_work")]
         public static extern int syrfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* a,
-            int lda, double* af,
+            int nrhs, /* const */ [In] double* a,
+            int lda, /* const */ [In] double* af,
             int ldaf, int* ipiv,
-            double* b, int ldb, double* x,
+            /* const */ [In] double* b, int ldb, double* x,
             int ldx, double* ferr, double* berr,
             double* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsyrfsx")]
         public static extern int syrfsx(Layout layout, UpLoChar uplo, char equed,
-            int n, int nrhs, double* a,
-            int lda, double* af, int ldaf,
-            int* ipiv, double* s,
-            double* b, int ldb, double* x,
+            int n, int nrhs, /* const */ [In] double* a,
+            int lda, /* const */ [In] double* af, int ldaf,
+            int* ipiv, /* const */ [In] double* s,
+            /* const */ [In] double* b, int ldb, double* x,
             int ldx, double* rcond, double* berr,
             int n_err_bnds, double* err_bnds_norm,
             double* err_bnds_comp, int nparams,
@@ -2384,10 +2384,10 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsyrfsx_work")]
         public static extern int syrfsx(Layout layout, UpLoChar uplo, char equed,
-            int n, int nrhs, double* a,
-            int lda, double* af,
+            int n, int nrhs, /* const */ [In] double* a,
+            int lda, /* const */ [In] double* af,
             int ldaf, int* ipiv,
-            double* s, double* b,
+            /* const */ [In] double* s, /* const */ [In] double* b,
             int ldb, double* x, int ldx,
             double* rcond, double* berr,
             int n_err_bnds, double* err_bnds_norm,
@@ -2419,17 +2419,17 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsysvx")]
         public static extern int sysvx(Layout layout, char fact, UpLoChar uplo, int n,
-            int nrhs, double* a, int lda,
+            int nrhs, /* const */ [In] double* a, int lda,
             double* af, int ldaf, int* ipiv,
-            double* b, int ldb, double* x,
+            /* const */ [In] double* b, int ldb, double* x,
             int ldx, double* rcond, double* ferr,
             double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsysvx_work")]
         public static extern int sysvx(Layout layout, char fact, UpLoChar uplo,
-            int n, int nrhs, double* a,
+            int n, int nrhs, /* const */ [In] double* a,
             int lda, double* af, int ldaf,
-            int* ipiv, double* b,
+            int* ipiv, /* const */ [In] double* b,
             int ldb, double* x, int ldx,
             double* rcond, double* ferr, double* berr,
             double* work, int lwork,
@@ -2521,62 +2521,62 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsytrs")]
         public static extern int sytrs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* a, int lda,
+            int nrhs, /* const */ [In] double* a, int lda,
             int* ipiv, double* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsytrs2")]
         public static extern int sytrs2(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* a, int lda,
+            int nrhs, /* const */ [In] double* a, int lda,
             int* ipiv, double* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsytrs2_work")]
         public static extern int sytrs2(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* a,
+            int nrhs, /* const */ [In] double* a,
             int lda, int* ipiv,
             double* b, int ldb, double* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsytrs_rook")]
         public static extern int sytrs_rook(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* a, int lda,
+            int nrhs, /* const */ [In] double* a, int lda,
             int* ipiv, double* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtbcon")]
         public static extern int tbcon(Layout layout, Norm norm, UpLoChar uplo, DiagChar diag,
-            int n, int kd, double* ab,
+            int n, int kd, /* const */ [In] double* ab,
             int ldab, double* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtbcon_work")]
         public static extern int tbcon(Layout layout, Norm norm, UpLoChar uplo,
             DiagChar diag, int n, int kd,
-            double* ab, int ldab,
+            /* const */ [In] double* ab, int ldab,
             double* rcond, double* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtbrfs")]
         public static extern int tbrfs(Layout layout, UpLoChar uplo, TransChar trans, DiagChar diag,
             int n, int kd, int nrhs,
-            double* ab, int ldab, double* b,
-            int ldb, double* x, int ldx,
+            /* const */ [In] double* ab, int ldab, /* const */ [In] double* b,
+            int ldb, /* const */ [In] double* x, int ldx,
             double* ferr, double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtbrfs_work")]
         public static extern int tbrfs(Layout layout, UpLoChar uplo, TransChar trans,
             DiagChar diag, int n, int kd,
-            int nrhs, double* ab,
-            int ldab, double* b,
-            int ldb, double* x, int ldx,
+            int nrhs, /* const */ [In] double* ab,
+            int ldab, /* const */ [In] double* b,
+            int ldb, /* const */ [In] double* x, int ldx,
             double* ferr, double* berr, double* work,
             int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtbtrs")]
         public static extern int tbtrs(Layout layout, UpLoChar uplo, TransChar trans, DiagChar diag,
             int n, int kd, int nrhs,
-            double* ab, int ldab, double* b,
+            /* const */ [In] double* ab, int ldab, double* b,
             int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtfsm")]
         public static extern int tfsm(Layout layout, TransChar transr, char side, UpLoChar uplo,
             TransChar trans, DiagChar diag, int m, int n,
-            double alpha, double* a, double* b,
+            double alpha, /* const */ [In] double* a, double* b,
             int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtftri")]
@@ -2585,17 +2585,17 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtfttp")]
         public static extern int tfttp(Layout layout, TransChar transr, UpLoChar uplo,
-            int n, double* arf, double* ap);
+            int n, /* const */ [In] double* arf, double* ap);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtfttr")]
         public static extern int tfttr(Layout layout, TransChar transr, UpLoChar uplo,
-            int n, double* arf, double* a,
+            int n, /* const */ [In] double* arf, double* a,
             int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtgevc")]
         public static extern int tgevc(Layout layout, char side, char howmny,
             int* select, int n,
-            double* s, int lds, double* p,
+            /* const */ [In] double* s, int lds, /* const */ [In] double* p,
             int ldp, double* vl, int ldvl,
             double* vr, int ldvr, int mm,
             int* m);
@@ -2603,8 +2603,8 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtgevc_work")]
         public static extern int tgevc(Layout layout, char side, char howmny,
             int* select, int n,
-            double* s, int lds,
-            double* p, int ldp, double* vl,
+            /* const */ [In] double* s, int lds,
+            /* const */ [In] double* p, int ldp, double* vl,
             int ldvl, double* vr, int ldvr,
             int mm, int* m, double* work);
 
@@ -2669,63 +2669,63 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtgsna")]
         public static extern int tgsna(Layout layout, char job, char howmny,
             int* select, int n,
-            double* a, int lda, double* b,
-            int ldb, double* vl, int ldvl,
-            double* vr, int ldvr, double* s,
+            /* const */ [In] double* a, int lda, /* const */ [In] double* b,
+            int ldb, /* const */ [In] double* vl, int ldvl,
+            /* const */ [In] double* vr, int ldvr, double* s,
             double* dif, int mm, int* m);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtgsna_work")]
         public static extern int tgsna(Layout layout, char job, char howmny,
             int* select, int n,
-            double* a, int lda,
-            double* b, int ldb,
-            double* vl, int ldvl,
-            double* vr, int ldvr, double* s,
+            /* const */ [In] double* a, int lda,
+            /* const */ [In] double* b, int ldb,
+            /* const */ [In] double* vl, int ldvl,
+            /* const */ [In] double* vr, int ldvr, double* s,
             double* dif, int mm, int* m,
             double* work, int lwork,
             int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtgsyl")]
         public static extern int tgsyl(Layout layout, TransChar trans, int ijob,
-            int m, int n, double* a,
-            int lda, double* b, int ldb,
-            double* c, int ldc, double* d,
-            int ldd, double* e, int lde,
+            int m, int n, /* const */ [In] double* a,
+            int lda, /* const */ [In] double* b, int ldb,
+            double* c, int ldc, /* const */ [In] double* d,
+            int ldd, /* const */ [In] double* e, int lde,
             double* f, int ldf, double* scale,
             double* dif);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtgsyl_work")]
         public static extern int tgsyl(Layout layout, TransChar trans, int ijob,
-            int m, int n, double* a,
-            int lda, double* b, int ldb,
-            double* c, int ldc, double* d,
-            int ldd, double* e, int lde,
+            int m, int n, /* const */ [In] double* a,
+            int lda, /* const */ [In] double* b, int ldb,
+            double* c, int ldc, /* const */ [In] double* d,
+            int ldd, /* const */ [In] double* e, int lde,
             double* f, int ldf, double* scale,
             double* dif, double* work, int lwork,
             int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtpcon")]
         public static extern int tpcon(Layout layout, Norm norm, UpLoChar uplo, DiagChar diag,
-            int n, double* ap, double* rcond);
+            int n, /* const */ [In] double* ap, double* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtpcon_work")]
         public static extern int tpcon(Layout layout, Norm norm, UpLoChar uplo,
-            DiagChar diag, int n, double* ap,
+            DiagChar diag, int n, /* const */ [In] double* ap,
             double* rcond, double* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtpmqrt")]
         public static extern int tpmqrt(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            int l, int nb, double* v,
-            int ldv, double* t, int ldt,
+            int l, int nb, /* const */ [In] double* v,
+            int ldv, /* const */ [In] double* t, int ldt,
             double* a, int lda, double* b,
             int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtpmqrt_work")]
         public static extern int tpmqrt(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            int l, int nb, double* v,
-            int ldv, double* t,
+            int l, int nb, /* const */ [In] double* v,
+            int ldv, /* const */ [In] double* t,
             int ldt, double* a, int lda,
             double* b, int ldb, double* work);
 
@@ -2749,30 +2749,30 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtprfb")]
         public static extern int tprfb(Layout layout, char side, TransChar trans, char direct,
             char storev, int m, int n,
-            int k, int l, double* v,
-            int ldv, double* t, int ldt,
+            int k, int l, /* const */ [In] double* v,
+            int ldv, /* const */ [In] double* t, int ldt,
             double* a, int lda, double* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtprfb_work")]
         public static extern int tprfb(Layout layout, char side, TransChar trans,
             char direct, char storev, int m,
             int n, int k, int l,
-            double* v, int ldv,
-            double* t, int ldt, double* a,
+            /* const */ [In] double* v, int ldv,
+            /* const */ [In] double* t, int ldt, double* a,
             int lda, double* b, int ldb,
             double* work, int ldwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtprfs")]
         public static extern int tprfs(Layout layout, UpLoChar uplo, TransChar trans, DiagChar diag,
-            int n, int nrhs, double* ap,
-            double* b, int ldb, double* x,
+            int n, int nrhs, /* const */ [In] double* ap,
+            /* const */ [In] double* b, int ldb, /* const */ [In] double* x,
             int ldx, double* ferr, double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtprfs_work")]
         public static extern int tprfs(Layout layout, UpLoChar uplo, TransChar trans,
             DiagChar diag, int n, int nrhs,
-            double* ap, double* b,
-            int ldb, double* x, int ldx,
+            /* const */ [In] double* ap, /* const */ [In] double* b,
+            int ldb, /* const */ [In] double* x, int ldx,
             double* ferr, double* berr, double* work,
             int* iwork);
 
@@ -2782,39 +2782,39 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtptrs")]
         public static extern int tptrs(Layout layout, UpLoChar uplo, TransChar trans, DiagChar diag,
-            int n, int nrhs, double* ap,
+            int n, int nrhs, /* const */ [In] double* ap,
             double* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtpttf")]
         public static extern int tpttf(Layout layout, TransChar transr, UpLoChar uplo,
-            int n, double* ap, double* arf);
+            int n, /* const */ [In] double* ap, double* arf);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtpttr")]
         public static extern int tpttr(Layout layout, UpLoChar uplo, int n,
-            double* ap, double* a, int lda);
+            /* const */ [In] double* ap, double* a, int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtrcon")]
         public static extern int trcon(Layout layout, Norm norm, UpLoChar uplo, DiagChar diag,
-            int n, double* a, int lda,
+            int n, /* const */ [In] double* a, int lda,
             double* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtrcon_work")]
         public static extern int trcon(Layout layout, Norm norm, UpLoChar uplo,
-            DiagChar diag, int n, double* a,
+            DiagChar diag, int n, /* const */ [In] double* a,
             int lda, double* rcond, double* work,
             int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtrevc")]
         public static extern int trevc(Layout layout, char side, char howmny,
             int* select, int n,
-            double* t, int ldt, double* vl,
+            /* const */ [In] double* t, int ldt, double* vl,
             int ldvl, double* vr, int ldvr,
             int mm, int* m);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtrevc_work")]
         public static extern int trevc(Layout layout, char side, char howmny,
             int* select, int n,
-            double* t, int ldt, double* vl,
+            /* const */ [In] double* t, int ldt, double* vl,
             int ldvl, double* vr, int ldvr,
             int mm, int* m, double* work);
 
@@ -2831,17 +2831,17 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtrrfs")]
         public static extern int trrfs(Layout layout, UpLoChar uplo, TransChar trans, DiagChar diag,
-            int n, int nrhs, double* a,
-            int lda, double* b, int ldb,
-            double* x, int ldx, double* ferr,
+            int n, int nrhs, /* const */ [In] double* a,
+            int lda, /* const */ [In] double* b, int ldb,
+            /* const */ [In] double* x, int ldx, double* ferr,
             double* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtrrfs_work")]
         public static extern int trrfs(Layout layout, UpLoChar uplo, TransChar trans,
             DiagChar diag, int n, int nrhs,
-            double* a, int lda,
-            double* b, int ldb,
-            double* x, int ldx, double* ferr,
+            /* const */ [In] double* a, int lda,
+            /* const */ [In] double* b, int ldb,
+            /* const */ [In] double* x, int ldx, double* ferr,
             double* berr, double* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtrsen")]
@@ -2863,17 +2863,17 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtrsna")]
         public static extern int trsna(Layout layout, char job, char howmny,
             int* select, int n,
-            double* t, int ldt, double* vl,
-            int ldvl, double* vr, int ldvr,
+            /* const */ [In] double* t, int ldt, /* const */ [In] double* vl,
+            int ldvl, /* const */ [In] double* vr, int ldvr,
             double* s, double* sep, int mm,
             int* m);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtrsna_work")]
         public static extern int trsna(Layout layout, char job, char howmny,
             int* select, int n,
-            double* t, int ldt,
-            double* vl, int ldvl,
-            double* vr, int ldvr, double* s,
+            /* const */ [In] double* t, int ldt,
+            /* const */ [In] double* vl, int ldvl,
+            /* const */ [In] double* vr, int ldvr, double* s,
             double* sep, int mm, int* m,
             double* work, int ldwork,
             int* iwork);
@@ -2881,7 +2881,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtrsyl")]
         public static extern int trsyl(Layout layout, char trana, char tranb,
             int isgn, int m, int n,
-            double* a, int lda, double* b,
+            /* const */ [In] double* a, int lda, /* const */ [In] double* b,
             int ldb, double* c, int ldc,
             double* scale);
 
@@ -2891,17 +2891,17 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtrtrs")]
         public static extern int trtrs(Layout layout, UpLoChar uplo, TransChar trans, DiagChar diag,
-            int n, int nrhs, double* a,
+            int n, int nrhs, /* const */ [In] double* a,
             int lda, double* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtrttf")]
         public static extern int trttf(Layout layout, TransChar transr, UpLoChar uplo,
-            int n, double* a, int lda,
+            int n, /* const */ [In] double* a, int lda,
             double* arf);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtrttp")]
         public static extern int trttp(Layout layout, UpLoChar uplo, int n,
-            double* a, int lda, double* ap);
+            /* const */ [In] double* a, int lda, double* ap);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dtzrzf")]
         public static extern int tzrzf(Layout layout, int m, int n,
@@ -3005,7 +3005,7 @@ public static partial class Lapack
             float* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sdisna")]
-        public static extern int disna(char job, int m, int n, float* d,
+        public static extern int disna(char job, int m, int n, /* const */ [In] float* d,
             float* sep);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgbbrd")]
@@ -3025,43 +3025,43 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgbcon")]
         public static extern int gbcon(Layout layout, Norm norm, int n,
-            int kl, int ku, float* ab,
+            int kl, int ku, /* const */ [In] float* ab,
             int ldab, int* ipiv, float anorm,
             float* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgbcon_work")]
         public static extern int gbcon(Layout layout, Norm norm, int n,
-            int kl, int ku, float* ab,
+            int kl, int ku, /* const */ [In] float* ab,
             int ldab, int* ipiv,
             float anorm, float* rcond, float* work,
             int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgbequ")]
         public static extern int gbequ(Layout layout, int m, int n,
-            int kl, int ku, float* ab,
+            int kl, int ku, /* const */ [In] float* ab,
             int ldab, float* r, float* c, float* rowcnd,
             float* colcnd, float* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgbequb")]
         public static extern int gbequb(Layout layout, int m, int n,
-            int kl, int ku, float* ab,
+            int kl, int ku, /* const */ [In] float* ab,
             int ldab, float* r, float* c, float* rowcnd,
             float* colcnd, float* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgbrfs")]
         public static extern int gbrfs(Layout layout, TransChar trans, int n,
             int kl, int ku, int nrhs,
-            float* ab, int ldab, float* afb,
+            /* const */ [In] float* ab, int ldab, /* const */ [In] float* afb,
             int ldafb, int* ipiv,
-            float* b, int ldb, float* x,
+            /* const */ [In] float* b, int ldb, float* x,
             int ldx, float* ferr, float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgbrfs_work")]
         public static extern int gbrfs(Layout layout, TransChar trans, int n,
             int kl, int ku, int nrhs,
-            float* ab, int ldab,
-            float* afb, int ldafb,
-            int* ipiv, float* b,
+            /* const */ [In] float* ab, int ldab,
+            /* const */ [In] float* afb, int ldafb,
+            int* ipiv, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* ferr, float* berr, float* work,
             int* iwork);
@@ -3069,10 +3069,10 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgbrfsx")]
         public static extern int gbrfsx(Layout layout, TransChar trans, char equed,
             int n, int kl, int ku,
-            int nrhs, float* ab, int ldab,
-            float* afb, int ldafb,
-            int* ipiv, float* r,
-            float* c, float* b, int ldb,
+            int nrhs, /* const */ [In] float* ab, int ldab,
+            /* const */ [In] float* afb, int ldafb,
+            int* ipiv, /* const */ [In] float* r,
+            /* const */ [In] float* c, /* const */ [In] float* b, int ldb,
             float* x, int ldx, float* rcond, float* berr,
             int n_err_bnds, float* err_bnds_norm,
             float* err_bnds_comp, int nparams,
@@ -3081,10 +3081,10 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgbrfsx_work")]
         public static extern int gbrfsx(Layout layout, TransChar trans, char equed,
             int n, int kl, int ku,
-            int nrhs, float* ab,
-            int ldab, float* afb,
+            int nrhs, /* const */ [In] float* ab,
+            int ldab, /* const */ [In] float* afb,
             int ldafb, int* ipiv,
-            float* r, float* c, float* b,
+            /* const */ [In] float* r, /* const */ [In] float* c, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* rcond, float* berr,
             int n_err_bnds, float* err_bnds_norm,
@@ -3149,12 +3149,12 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgbtrs")]
         public static extern int gbtrs(Layout layout, TransChar trans, int n,
             int kl, int ku, int nrhs,
-            float* ab, int ldab,
+            /* const */ [In] float* ab, int ldab,
             int* ipiv, float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgebak")]
         public static extern int gebak(Layout layout, char job, char side, int n,
-            int ilo, int ihi, float* scale,
+            int ilo, int ihi, /* const */ [In] float* scale,
             int m, float* v, int ldv);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgebal")]
@@ -3175,22 +3175,22 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgecon")]
         public static extern int gecon(Layout layout, Norm norm, int n,
-            float* a, int lda, float anorm,
+            /* const */ [In] float* a, int lda, float anorm,
             float* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgecon_work")]
         public static extern int gecon(Layout layout, Norm norm, int n,
-            float* a, int lda, float anorm,
+            /* const */ [In] float* a, int lda, float anorm,
             float* rcond, float* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgeequ")]
         public static extern int geequ(Layout layout, int m, int n,
-            float* a, int lda, float* r, float* c,
+            /* const */ [In] float* a, int lda, float* r, float* c,
             float* rowcnd, float* colcnd, float* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgeequb")]
         public static extern int geequb(Layout layout, int m, int n,
-            float* a, int lda, float* r, float* c,
+            /* const */ [In] float* a, int lda, float* r, float* c,
             float* rowcnd, float* colcnd, float* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgeev")]
@@ -3321,15 +3321,15 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgemqrt")]
         public static extern int gemqrt(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            int nb, float* v, int ldv,
-            float* t, int ldt, float* c,
+            int nb, /* const */ [In] float* v, int ldv,
+            /* const */ [In] float* t, int ldt, float* c,
             int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgemqrt_work")]
         public static extern int gemqrt(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            int nb, float* v, int ldv,
-            float* t, int ldt, float* c,
+            int nb, /* const */ [In] float* v, int ldv,
+            /* const */ [In] float* t, int ldt, float* c,
             int ldc, float* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgeqlf")]
@@ -3408,27 +3408,27 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgerfs")]
         public static extern int gerfs(Layout layout, TransChar trans, int n,
-            int nrhs, float* a, int lda,
-            float* af, int ldaf,
-            int* ipiv, float* b,
+            int nrhs, /* const */ [In] float* a, int lda,
+            /* const */ [In] float* af, int ldaf,
+            int* ipiv, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* ferr, float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgerfs_work")]
         public static extern int gerfs(Layout layout, TransChar trans, int n,
-            int nrhs, float* a, int lda,
-            float* af, int ldaf,
-            int* ipiv, float* b,
+            int nrhs, /* const */ [In] float* a, int lda,
+            /* const */ [In] float* af, int ldaf,
+            int* ipiv, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* ferr, float* berr, float* work,
             int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgerfsx")]
         public static extern int gerfsx(Layout layout, TransChar trans, char equed,
-            int n, int nrhs, float* a,
-            int lda, float* af, int ldaf,
-            int* ipiv, float* r,
-            float* c, float* b, int ldb,
+            int n, int nrhs, /* const */ [In] float* a,
+            int lda, /* const */ [In] float* af, int ldaf,
+            int* ipiv, /* const */ [In] float* r,
+            /* const */ [In] float* c, /* const */ [In] float* b, int ldb,
             float* x, int ldx, float* rcond, float* berr,
             int n_err_bnds, float* err_bnds_norm,
             float* err_bnds_comp, int nparams,
@@ -3436,10 +3436,10 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgerfsx_work")]
         public static extern int gerfsx(Layout layout, TransChar trans, char equed,
-            int n, int nrhs, float* a,
-            int lda, float* af,
+            int n, int nrhs, /* const */ [In] float* a,
+            int lda, /* const */ [In] float* af,
             int ldaf, int* ipiv,
-            float* r, float* c, float* b,
+            /* const */ [In] float* r, /* const */ [In] float* c, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* rcond, float* berr,
             int n_err_bnds, float* err_bnds_norm,
@@ -3581,13 +3581,13 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgetrs")]
         public static extern int getrs(Layout layout, TransChar trans, int n,
-            int nrhs, float* a, int lda,
+            int nrhs, /* const */ [In] float* a, int lda,
             int* ipiv, float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sggbak")]
         public static extern int ggbak(Layout layout, char job, char side, int n,
-            int ilo, int ihi, float* lscale,
-            float* rscale, int m, float* v,
+            int ilo, int ihi, /* const */ [In] float* lscale,
+            /* const */ [In] float* rscale, int m, float* v,
             int ldv);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sggbal")]
@@ -3798,33 +3798,33 @@ public static partial class Lapack
             int* iwork, float* tau, float* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgtcon")]
-        public static extern int gtcon(Norm norm, int n, float* dl,
-            float* d, float* du, float* du2,
+        public static extern int gtcon(Norm norm, int n, /* const */ [In] float* dl,
+            /* const */ [In] float* d, /* const */ [In] float* du, /* const */ [In] float* du2,
             int* ipiv, float anorm, float* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgtcon_work")]
-        public static extern int gtcon(Norm norm, int n, float* dl,
-            float* d, float* du,
-            float* du2, int* ipiv,
+        public static extern int gtcon(Norm norm, int n, /* const */ [In] float* dl,
+            /* const */ [In] float* d, /* const */ [In] float* du,
+            /* const */ [In] float* du2, int* ipiv,
             float anorm, float* rcond, float* work,
             int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgtrfs")]
         public static extern int gtrfs(Layout layout, TransChar trans, int n,
-            int nrhs, float* dl, float* d,
-            float* du, float* dlf, float* df,
-            float* duf, float* du2,
-            int* ipiv, float* b,
+            int nrhs, /* const */ [In] float* dl, /* const */ [In] float* d,
+            /* const */ [In] float* du, /* const */ [In] float* dlf, /* const */ [In] float* df,
+            /* const */ [In] float* duf, /* const */ [In] float* du2,
+            int* ipiv, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* ferr, float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgtrfs_work")]
         public static extern int gtrfs(Layout layout, TransChar trans, int n,
-            int nrhs, float* dl,
-            float* d, float* du,
-            float* dlf, float* df,
-            float* duf, float* du2,
-            int* ipiv, float* b,
+            int nrhs, /* const */ [In] float* dl,
+            /* const */ [In] float* d, /* const */ [In] float* du,
+            /* const */ [In] float* dlf, /* const */ [In] float* df,
+            /* const */ [In] float* duf, /* const */ [In] float* du2,
+            int* ipiv, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* ferr, float* berr, float* work,
             int* iwork);
@@ -3836,19 +3836,19 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgtsvx")]
         public static extern int gtsvx(Layout layout, char fact, TransChar trans,
-            int n, int nrhs, float* dl,
-            float* d, float* du, float* dlf,
+            int n, int nrhs, /* const */ [In] float* dl,
+            /* const */ [In] float* d, /* const */ [In] float* du, float* dlf,
             float* df, float* duf, float* du2, int* ipiv,
-            float* b, int ldb, float* x,
+            /* const */ [In] float* b, int ldb, float* x,
             int ldx, float* rcond, float* ferr,
             float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgtsvx_work")]
         public static extern int gtsvx(Layout layout, char fact, TransChar trans,
-            int n, int nrhs, float* dl,
-            float* d, float* du, float* dlf,
+            int n, int nrhs, /* const */ [In] float* dl,
+            /* const */ [In] float* d, /* const */ [In] float* du, float* dlf,
             float* df, float* duf, float* du2,
-            int* ipiv, float* b,
+            int* ipiv, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* rcond, float* ferr, float* berr,
             float* work, int* iwork);
@@ -3859,8 +3859,8 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgttrs")]
         public static extern int gttrs(Layout layout, TransChar trans, int n,
-            int nrhs, float* dl, float* d,
-            float* du, float* du2,
+            int nrhs, /* const */ [In] float* dl, /* const */ [In] float* d,
+            /* const */ [In] float* du, /* const */ [In] float* du2,
             int* ipiv, float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_shgeqz")]
@@ -3881,8 +3881,8 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_shsein")]
         public static extern int hsein(Layout layout, char job, char eigsrc, char initv,
-            int* select, int n, float* h,
-            int ldh, float* wr, float* wi,
+            int* select, int n, /* const */ [In] float* h,
+            int ldh, float* wr, /* const */ [In] float* wi,
             float* vl, int ldvl, float* vr,
             int ldvr, int mm, int* m,
             int* ifaill, int* ifailr);
@@ -3890,8 +3890,8 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_shsein_work")]
         public static extern int hsein(Layout layout, char job, char eigsrc,
             char initv, int* select,
-            int n, float* h, int ldh,
-            float* wr, float* wi, float* vl,
+            int n, /* const */ [In] float* h, int ldh,
+            float* wr, /* const */ [In] float* wi, float* vl,
             int ldvl, float* vr, int ldvr,
             int mm, int* m, float* work,
             int* ifaill, int* ifailr);
@@ -3915,33 +3915,33 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slacpy")]
         public static extern int lacpy(Layout layout, UpLoChar uplo, int m,
-            int n, float* a, int lda,
+            int n, /* const */ [In] float* a, int lda,
             float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slag2d")]
         public static extern int lag2d(Layout layout, int m, int n,
-            float* sa, int ldsa, double* a,
+            /* const */ [In] float* sa, int ldsa, double* a,
             int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slagge")]
         public static extern int lagge(Layout layout, int m, int n,
-            int kl, int ku, float* d,
+            int kl, int ku, /* const */ [In] float* d,
             float* a, int lda, int* iseed);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slagge_work")]
         public static extern int lagge(Layout layout, int m, int n,
-            int kl, int ku, float* d,
+            int kl, int ku, /* const */ [In] float* d,
             float* a, int lda, int* iseed,
             float* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slagsy")]
         public static extern int lagsy(Layout layout, int n, int k,
-            float* d, float* a, int lda,
+            /* const */ [In] float* d, float* a, int lda,
             int* iseed);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slagsy_work")]
         public static extern int lagsy(Layout layout, int n, int k,
-            float* d, float* a, int lda,
+            /* const */ [In] float* d, float* a, int lda,
             int* iseed, float* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slapmr")]
@@ -3957,15 +3957,15 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slarfb")]
         public static extern int larfb(Layout layout, char side, TransChar trans, char direct,
             char storev, int m, int n,
-            int k, float* v, int ldv,
-            float* t, int ldt, float* c,
+            int k, /* const */ [In] float* v, int ldv,
+            /* const */ [In] float* t, int ldt, float* c,
             int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slarfb_work")]
         public static extern int larfb(Layout layout, char side, TransChar trans,
             char direct, char storev, int m,
-            int n, int k, float* v,
-            int ldv, float* t, int ldt,
+            int n, int k, /* const */ [In] float* v,
+            int ldv, /* const */ [In] float* t, int ldt,
             float* c, int ldc, float* work,
             int ldwork);
 
@@ -3975,13 +3975,13 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slarft")]
         public static extern int larft(Layout layout, char direct, char storev,
-            int n, int k, float* v,
-            int ldv, float* tau, float* t,
+            int n, int k, /* const */ [In] float* v,
+            int ldv, /* const */ [In] float* tau, float* t,
             int ldt);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slarfx")]
         public static extern int larfx(Layout layout, char side, int m,
-            int n, float* v, float tau, float* c,
+            int n, /* const */ [In] float* v, float tau, float* c,
             int ldc, float* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_slarnv")]
@@ -4035,23 +4035,23 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sopgtr")]
         public static extern int opgtr(Layout layout, UpLoChar uplo, int n,
-            float* ap, float* tau, float* q,
+            /* const */ [In] float* ap, /* const */ [In] float* tau, float* q,
             int ldq);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sopgtr_work")]
         public static extern int opgtr(Layout layout, UpLoChar uplo, int n,
-            float* ap, float* tau, float* q,
+            /* const */ [In] float* ap, /* const */ [In] float* tau, float* q,
             int ldq, float* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sopmtr")]
         public static extern int opmtr(Layout layout, char side, UpLoChar uplo, TransChar trans,
-            int m, int n, float* ap,
-            float* tau, float* c, int ldc);
+            int m, int n, /* const */ [In] float* ap,
+            /* const */ [In] float* tau, float* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sopmtr_work")]
         public static extern int opmtr(Layout layout, char side, UpLoChar uplo,
             TransChar trans, int m, int n,
-            float* ap, float* tau, float* c,
+            /* const */ [In] float* ap, /* const */ [In] float* tau, float* c,
             int ldc, float* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sorbdb")]
@@ -4122,7 +4122,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sorgbr_work")]
         public static extern int orgbr(Layout layout, char vect, int m,
             int n, int k, float* a,
-            int lda, float* tau, float* work,
+            int lda, /* const */ [In] float* tau, float* work,
             int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sorghr")]
@@ -4133,7 +4133,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sorghr_work")]
         public static extern int orghr(Layout layout, int n, int ilo,
             int ihi, float* a, int lda,
-            float* tau, float* work,
+            /* const */ [In] float* tau, float* work,
             int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sorglq")]
@@ -4144,7 +4144,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sorglq_work")]
         public static extern int orglq(Layout layout, int m, int n,
             int k, float* a, int lda,
-            float* tau, float* work,
+            /* const */ [In] float* tau, float* work,
             int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sorgql")]
@@ -4155,7 +4155,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sorgql_work")]
         public static extern int orgql(Layout layout, int m, int n,
             int k, float* a, int lda,
-            float* tau, float* work,
+            /* const */ [In] float* tau, float* work,
             int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sorgqr")]
@@ -4166,7 +4166,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sorgqr_work")]
         public static extern int orgqr(Layout layout, int m, int n,
             int k, float* a, int lda,
-            float* tau, float* work,
+            /* const */ [In] float* tau, float* work,
             int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sorgrq")]
@@ -4177,7 +4177,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sorgrq_work")]
         public static extern int orgrq(Layout layout, int m, int n,
             int k, float* a, int lda,
-            float* tau, float* work,
+            /* const */ [In] float* tau, float* work,
             int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sorgtr")]
@@ -4186,141 +4186,141 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sorgtr_work")]
         public static extern int orgtr(Layout layout, UpLoChar uplo, int n,
-            float* a, int lda, float* tau,
+            float* a, int lda, /* const */ [In] float* tau,
             float* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormbr")]
         public static extern int ormbr(Layout layout, char vect, char side, TransChar trans,
             int m, int n, int k,
-            float* a, int lda, float* tau,
+            /* const */ [In] float* a, int lda, /* const */ [In] float* tau,
             float* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormbr_work")]
         public static extern int ormbr(Layout layout, char vect, char side,
             TransChar trans, int m, int n,
-            int k, float* a, int lda,
-            float* tau, float* c, int ldc,
+            int k, /* const */ [In] float* a, int lda,
+            /* const */ [In] float* tau, float* c, int ldc,
             float* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormhr")]
         public static extern int ormhr(Layout layout, char side, TransChar trans,
             int m, int n, int ilo,
-            int ihi, float* a, int lda,
-            float* tau, float* c, int ldc);
+            int ihi, /* const */ [In] float* a, int lda,
+            /* const */ [In] float* tau, float* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormhr_work")]
         public static extern int ormhr(Layout layout, char side, TransChar trans,
             int m, int n, int ilo,
-            int ihi, float* a, int lda,
-            float* tau, float* c, int ldc,
+            int ihi, /* const */ [In] float* a, int lda,
+            /* const */ [In] float* tau, float* c, int ldc,
             float* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormlq")]
         public static extern int ormlq(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            float* a, int lda, float* tau,
+            /* const */ [In] float* a, int lda, /* const */ [In] float* tau,
             float* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormlq_work")]
         public static extern int ormlq(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            float* a, int lda,
-            float* tau, float* c, int ldc,
+            /* const */ [In] float* a, int lda,
+            /* const */ [In] float* tau, float* c, int ldc,
             float* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormql")]
         public static extern int ormql(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            float* a, int lda, float* tau,
+            /* const */ [In] float* a, int lda, /* const */ [In] float* tau,
             float* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormql_work")]
         public static extern int ormql(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            float* a, int lda,
-            float* tau, float* c, int ldc,
+            /* const */ [In] float* a, int lda,
+            /* const */ [In] float* tau, float* c, int ldc,
             float* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormqr")]
         public static extern int ormqr(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            float* a, int lda, float* tau,
+            /* const */ [In] float* a, int lda, /* const */ [In] float* tau,
             float* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormqr_work")]
         public static extern int ormqr(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            float* a, int lda,
-            float* tau, float* c, int ldc,
+            /* const */ [In] float* a, int lda,
+            /* const */ [In] float* tau, float* c, int ldc,
             float* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormrq")]
         public static extern int ormrq(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            float* a, int lda, float* tau,
+            /* const */ [In] float* a, int lda, /* const */ [In] float* tau,
             float* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormrq_work")]
         public static extern int ormrq(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            float* a, int lda,
-            float* tau, float* c, int ldc,
+            /* const */ [In] float* a, int lda,
+            /* const */ [In] float* tau, float* c, int ldc,
             float* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormrz")]
         public static extern int ormrz(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            int l, float* a, int lda,
-            float* tau, float* c, int ldc);
+            int l, /* const */ [In] float* a, int lda,
+            /* const */ [In] float* tau, float* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormrz_work")]
         public static extern int ormrz(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            int l, float* a, int lda,
-            float* tau, float* c, int ldc,
+            int l, /* const */ [In] float* a, int lda,
+            /* const */ [In] float* tau, float* c, int ldc,
             float* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormtr")]
         public static extern int ormtr(Layout layout, char side, UpLoChar uplo, TransChar trans,
-            int m, int n, float* a,
-            int lda, float* tau, float* c,
+            int m, int n, /* const */ [In] float* a,
+            int lda, /* const */ [In] float* tau, float* c,
             int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sormtr_work")]
         public static extern int ormtr(Layout layout, char side, UpLoChar uplo,
             TransChar trans, int m, int n,
-            float* a, int lda,
-            float* tau, float* c, int ldc,
+            /* const */ [In] float* a, int lda,
+            /* const */ [In] float* tau, float* c, int ldc,
             float* work, int lwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spbcon")]
         public static extern int pbcon(Layout layout, UpLoChar uplo, int n,
-            int kd, float* ab, int ldab,
+            int kd, /* const */ [In] float* ab, int ldab,
             float anorm, float* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spbcon_work")]
         public static extern int pbcon(Layout layout, UpLoChar uplo, int n,
-            int kd, float* ab, int ldab,
+            int kd, /* const */ [In] float* ab, int ldab,
             float anorm, float* rcond, float* work,
             int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spbequ")]
         public static extern int pbequ(Layout layout, UpLoChar uplo, int n,
-            int kd, float* ab, int ldab,
+            int kd, /* const */ [In] float* ab, int ldab,
             float* s, float* scond, float* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spbrfs")]
         public static extern int pbrfs(Layout layout, UpLoChar uplo, int n,
-            int kd, int nrhs, float* ab,
-            int ldab, float* afb, int ldafb,
-            float* b, int ldb, float* x,
+            int kd, int nrhs, /* const */ [In] float* ab,
+            int ldab, /* const */ [In] float* afb, int ldafb,
+            /* const */ [In] float* b, int ldb, float* x,
             int ldx, float* ferr, float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spbrfs_work")]
         public static extern int pbrfs(Layout layout, UpLoChar uplo, int n,
-            int kd, int nrhs, float* ab,
-            int ldab, float* afb,
-            int ldafb, float* b,
+            int kd, int nrhs, /* const */ [In] float* ab,
+            int ldab, /* const */ [In] float* afb,
+            int ldafb, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* ferr, float* berr, float* work,
             int* iwork);
@@ -4357,7 +4357,7 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spbtrs")]
         public static extern int pbtrs(Layout layout, UpLoChar uplo, int n,
-            int kd, int nrhs, float* ab,
+            int kd, int nrhs, /* const */ [In] float* ab,
             int ldab, float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spftrf")]
@@ -4370,49 +4370,49 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spftrs")]
         public static extern int pftrs(Layout layout, TransChar transr, UpLoChar uplo,
-            int n, int nrhs, float* a,
+            int n, int nrhs, /* const */ [In] float* a,
             float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spocon")]
         public static extern int pocon(Layout layout, UpLoChar uplo, int n,
-            float* a, int lda, float anorm,
+            /* const */ [In] float* a, int lda, float anorm,
             float* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spocon_work")]
         public static extern int pocon(Layout layout, UpLoChar uplo, int n,
-            float* a, int lda, float anorm,
+            /* const */ [In] float* a, int lda, float anorm,
             float* rcond, float* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spoequ")]
-        public static extern int poequ(Layout layout, int n, float* a,
+        public static extern int poequ(Layout layout, int n, /* const */ [In] float* a,
             int lda, float* s, float* scond, float* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spoequb")]
-        public static extern int poequb(Layout layout, int n, float* a,
+        public static extern int poequb(Layout layout, int n, /* const */ [In] float* a,
             int lda, float* s, float* scond,
             float* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sporfs")]
         public static extern int porfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* a, int lda,
-            float* af, int ldaf, float* b,
+            int nrhs, /* const */ [In] float* a, int lda,
+            /* const */ [In] float* af, int ldaf, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* ferr, float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sporfs_work")]
         public static extern int porfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* a,
-            int lda, float* af,
-            int ldaf, float* b,
+            int nrhs, /* const */ [In] float* a,
+            int lda, /* const */ [In] float* af,
+            int ldaf, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* ferr, float* berr, float* work,
             int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sporfsx")]
         public static extern int porfsx(Layout layout, UpLoChar uplo, char equed,
-            int n, int nrhs, float* a,
-            int lda, float* af, int ldaf,
-            float* s, float* b, int ldb,
+            int n, int nrhs, /* const */ [In] float* a,
+            int lda, /* const */ [In] float* af, int ldaf,
+            /* const */ [In] float* s, /* const */ [In] float* b, int ldb,
             float* x, int ldx, float* rcond, float* berr,
             int n_err_bnds, float* err_bnds_norm,
             float* err_bnds_comp, int nparams,
@@ -4420,10 +4420,10 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sporfsx_work")]
         public static extern int porfsx(Layout layout, UpLoChar uplo, char equed,
-            int n, int nrhs, float* a,
-            int lda, float* af,
-            int ldaf, float* s,
-            float* b, int ldb, float* x,
+            int n, int nrhs, /* const */ [In] float* a,
+            int lda, /* const */ [In] float* af,
+            int ldaf, /* const */ [In] float* s,
+            /* const */ [In] float* b, int ldb, float* x,
             int ldx, float* rcond, float* berr,
             int n_err_bnds, float* err_bnds_norm,
             float* err_bnds_comp, int nparams,
@@ -4487,33 +4487,33 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spotrs")]
         public static extern int potrs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* a, int lda,
+            int nrhs, /* const */ [In] float* a, int lda,
             float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sppcon")]
         public static extern int ppcon(Layout layout, UpLoChar uplo, int n,
-            float* ap, float anorm, float* rcond);
+            /* const */ [In] float* ap, float anorm, float* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sppcon_work")]
         public static extern int ppcon(Layout layout, UpLoChar uplo, int n,
-            float* ap, float anorm, float* rcond,
+            /* const */ [In] float* ap, float anorm, float* rcond,
             float* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sppequ")]
         public static extern int ppequ(Layout layout, UpLoChar uplo, int n,
-            float* ap, float* s, float* scond,
+            /* const */ [In] float* ap, float* s, float* scond,
             float* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spprfs")]
         public static extern int pprfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* ap, float* afp,
-            float* b, int ldb, float* x,
+            int nrhs, /* const */ [In] float* ap, /* const */ [In] float* afp,
+            /* const */ [In] float* b, int ldb, float* x,
             int ldx, float* ferr, float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spprfs_work")]
         public static extern int pprfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* ap,
-            float* afp, float* b,
+            int nrhs, /* const */ [In] float* ap,
+            /* const */ [In] float* afp, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* ferr, float* berr, float* work,
             int* iwork);
@@ -4547,7 +4547,7 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spptrs")]
         public static extern int pptrs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* ap, float* b,
+            int nrhs, /* const */ [In] float* ap, float* b,
             int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spstrf")]
@@ -4561,11 +4561,11 @@ public static partial class Lapack
             ref int rank, float tol, float* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sptcon")]
-        public static extern int ptcon(int n, float* d, float* e,
+        public static extern int ptcon(int n, /* const */ [In] float* d, /* const */ [In] float* e,
             float anorm, float* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sptcon_work")]
-        public static extern int ptcon(int n, float* d, float* e,
+        public static extern int ptcon(int n, /* const */ [In] float* d, /* const */ [In] float* e,
             float anorm, float* rcond, float* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spteqr")]
@@ -4579,14 +4579,14 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sptrfs")]
         public static extern int ptrfs(Layout layout, int n, int nrhs,
-            float* d, float* e, float* df,
-            float* ef, float* b, int ldb,
+            /* const */ [In] float* d, /* const */ [In] float* e, /* const */ [In] float* df,
+            /* const */ [In] float* ef, /* const */ [In] float* b, int ldb,
             float* x, int ldx, float* ferr, float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sptrfs_work")]
         public static extern int ptrfs(Layout layout, int n, int nrhs,
-            float* d, float* e, float* df,
-            float* ef, float* b, int ldb,
+            /* const */ [In] float* d, /* const */ [In] float* e, /* const */ [In] float* df,
+            /* const */ [In] float* ef, /* const */ [In] float* b, int ldb,
             float* x, int ldx, float* ferr,
             float* berr, float* work);
 
@@ -4596,15 +4596,15 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sptsvx")]
         public static extern int ptsvx(Layout layout, char fact, int n,
-            int nrhs, float* d, float* e,
-            float* df, float* ef, float* b, int ldb,
+            int nrhs, /* const */ [In] float* d, /* const */ [In] float* e,
+            float* df, float* ef, /* const */ [In] float* b, int ldb,
             float* x, int ldx, float* rcond, float* ferr,
             float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sptsvx_work")]
         public static extern int ptsvx(Layout layout, char fact, int n,
-            int nrhs, float* d, float* e,
-            float* df, float* ef, float* b,
+            int nrhs, /* const */ [In] float* d, /* const */ [In] float* e,
+            float* df, float* ef, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* rcond, float* ferr, float* berr,
             float* work);
@@ -4614,7 +4614,7 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_spttrs")]
         public static extern int pttrs(Layout layout, int n, int nrhs,
-            float* d, float* e, float* b,
+            /* const */ [In] float* d, /* const */ [In] float* e, float* b,
             int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssbev")]
@@ -4661,13 +4661,13 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssbgst")]
         public static extern int sbgst(Layout layout, char vect, UpLoChar uplo, int n,
             int ka, int kb, float* ab,
-            int ldab, float* bb, int ldbb,
+            int ldab, /* const */ [In] float* bb, int ldbb,
             float* x, int ldx);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssbgst_work")]
         public static extern int sbgst(Layout layout, char vect, UpLoChar uplo,
             int n, int ka, int kb,
-            float* ab, int ldab, float* bb,
+            float* ab, int ldab, /* const */ [In] float* bb,
             int ldbb, float* x, int ldx,
             float* work);
 
@@ -4732,16 +4732,16 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssfrk")]
         public static extern int sfrk(Layout layout, TransChar transr, UpLoChar uplo, TransChar trans,
             int n, int k, float alpha,
-            float* a, int lda, float beta, float* c);
+            /* const */ [In] float* a, int lda, float beta, float* c);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sspcon")]
         public static extern int spcon(Layout layout, UpLoChar uplo, int n,
-            float* ap, int* ipiv, float anorm,
+            /* const */ [In] float* ap, int* ipiv, float anorm,
             float* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sspcon_work")]
         public static extern int spcon(Layout layout, UpLoChar uplo, int n,
-            float* ap, int* ipiv,
+            /* const */ [In] float* ap, int* ipiv,
             float anorm, float* rcond, float* work,
             int* iwork);
 
@@ -4822,16 +4822,16 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssprfs")]
         public static extern int sprfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* ap, float* afp,
-            int* ipiv, float* b,
+            int nrhs, /* const */ [In] float* ap, /* const */ [In] float* afp,
+            int* ipiv, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* ferr, float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssprfs_work")]
         public static extern int sprfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* ap,
-            float* afp, int* ipiv,
-            float* b, int ldb, float* x,
+            int nrhs, /* const */ [In] float* ap,
+            /* const */ [In] float* afp, int* ipiv,
+            /* const */ [In] float* b, int ldb, float* x,
             int ldx, float* ferr, float* berr,
             float* work, int* iwork);
 
@@ -4842,15 +4842,15 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sspsvx")]
         public static extern int spsvx(Layout layout, char fact, UpLoChar uplo, int n,
-            int nrhs, float* ap, float* afp,
-            int* ipiv, float* b, int ldb,
+            int nrhs, /* const */ [In] float* ap, float* afp,
+            int* ipiv, /* const */ [In] float* b, int ldb,
             float* x, int ldx, float* rcond, float* ferr,
             float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sspsvx_work")]
         public static extern int spsvx(Layout layout, char fact, UpLoChar uplo,
-            int n, int nrhs, float* ap,
-            float* afp, int* ipiv, float* b,
+            int n, int nrhs, /* const */ [In] float* ap,
+            float* afp, int* ipiv, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* rcond, float* ferr, float* berr,
             float* work, int* iwork);
@@ -4873,20 +4873,20 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssptrs")]
         public static extern int sptrs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* ap,
+            int nrhs, /* const */ [In] float* ap,
             int* ipiv, float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sstebz")]
         public static extern int stebz(char range, char order, int n, float vl,
             float vu, int il, int iu, float abstol,
-            float* d, float* e, int* m,
+            /* const */ [In] float* d, /* const */ [In] float* e, int* m,
             int* nsplit, float* w, int* iblock,
             int* isplit);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sstebz_work")]
         public static extern int stebz(char range, char order, int n, float vl,
             float vu, int il, int iu,
-            float abstol, float* d, float* e,
+            float abstol, /* const */ [In] float* d, /* const */ [In] float* e,
             int* m, int* nsplit, float* w,
             int* iblock, int* isplit,
             float* work, int* iwork);
@@ -4918,14 +4918,14 @@ public static partial class Lapack
             int liwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sstein")]
-        public static extern int stein(Layout layout, int n, float* d,
-            float* e, int m, float* w,
+        public static extern int stein(Layout layout, int n, /* const */ [In] float* d,
+            /* const */ [In] float* e, int m, /* const */ [In] float* w,
             int* iblock, int* isplit,
             float* z, int ldz, int* ifailv);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sstein_work")]
-        public static extern int stein(Layout layout, int n, float* d,
-            float* e, int m, float* w,
+        public static extern int stein(Layout layout, int n, /* const */ [In] float* d,
+            /* const */ [In] float* e, int m, /* const */ [In] float* w,
             int* iblock,
             int* isplit, float* z,
             int ldz, float* work, int* iwork,
@@ -5012,12 +5012,12 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssycon")]
         public static extern int sycon(Layout layout, UpLoChar uplo, int n,
-            float* a, int lda,
+            /* const */ [In] float* a, int lda,
             int* ipiv, float anorm, float* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssycon_work")]
         public static extern int sycon(Layout layout, UpLoChar uplo, int n,
-            float* a, int lda,
+            /* const */ [In] float* a, int lda,
             int* ipiv, float anorm,
             float* rcond, float* work, int* iwork);
 
@@ -5028,12 +5028,12 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssyequb")]
         public static extern int syequb(Layout layout, UpLoChar uplo, int n,
-            float* a, int lda, float* s,
+            /* const */ [In] float* a, int lda, float* s,
             float* scond, float* amax);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssyequb_work")]
         public static extern int syequb(Layout layout, UpLoChar uplo, int n,
-            float* a, int lda, float* s,
+            /* const */ [In] float* a, int lda, float* s,
             float* scond, float* amax, float* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssyev")]
@@ -5091,7 +5091,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssygst")]
         public static extern int sygst(Layout layout, int itype, UpLoChar uplo,
             int n, float* a, int lda,
-            float* b, int ldb);
+            /* const */ [In] float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssygv")]
         public static extern int sygv(Layout layout, int itype, char jobz,
@@ -5136,27 +5136,27 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssyrfs")]
         public static extern int syrfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* a, int lda,
-            float* af, int ldaf,
-            int* ipiv, float* b,
+            int nrhs, /* const */ [In] float* a, int lda,
+            /* const */ [In] float* af, int ldaf,
+            int* ipiv, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* ferr, float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssyrfs_work")]
         public static extern int syrfs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* a, int lda,
-            float* af, int ldaf,
-            int* ipiv, float* b,
+            int nrhs, /* const */ [In] float* a, int lda,
+            /* const */ [In] float* af, int ldaf,
+            int* ipiv, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* ferr, float* berr, float* work,
             int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssyrfsx")]
         public static extern int syrfsx(Layout layout, UpLoChar uplo, char equed,
-            int n, int nrhs, float* a,
-            int lda, float* af, int ldaf,
-            int* ipiv, float* s,
-            float* b, int ldb, float* x,
+            int n, int nrhs, /* const */ [In] float* a,
+            int lda, /* const */ [In] float* af, int ldaf,
+            int* ipiv, /* const */ [In] float* s,
+            /* const */ [In] float* b, int ldb, float* x,
             int ldx, float* rcond, float* berr,
             int n_err_bnds, float* err_bnds_norm,
             float* err_bnds_comp, int nparams,
@@ -5164,10 +5164,10 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssyrfsx_work")]
         public static extern int syrfsx(Layout layout, UpLoChar uplo, char equed,
-            int n, int nrhs, float* a,
-            int lda, float* af,
+            int n, int nrhs, /* const */ [In] float* a,
+            int lda, /* const */ [In] float* af,
             int ldaf, int* ipiv,
-            float* s, float* b, int ldb,
+            /* const */ [In] float* s, /* const */ [In] float* b, int ldb,
             float* x, int ldx, float* rcond,
             float* berr, int n_err_bnds,
             float* err_bnds_norm, float* err_bnds_comp,
@@ -5198,17 +5198,17 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssysvx")]
         public static extern int sysvx(Layout layout, char fact, UpLoChar uplo, int n,
-            int nrhs, float* a, int lda,
+            int nrhs, /* const */ [In] float* a, int lda,
             float* af, int ldaf, int* ipiv,
-            float* b, int ldb, float* x,
+            /* const */ [In] float* b, int ldb, float* x,
             int ldx, float* rcond, float* ferr,
             float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssysvx_work")]
         public static extern int sysvx(Layout layout, char fact, UpLoChar uplo,
-            int n, int nrhs, float* a,
+            int n, int nrhs, /* const */ [In] float* a,
             int lda, float* af, int ldaf,
-            int* ipiv, float* b,
+            int* ipiv, /* const */ [In] float* b,
             int ldb, float* x, int ldx,
             float* rcond, float* ferr, float* berr,
             float* work, int lwork,
@@ -5300,61 +5300,61 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssytrs")]
         public static extern int sytrs(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* a, int lda,
+            int nrhs, /* const */ [In] float* a, int lda,
             int* ipiv, float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssytrs2")]
         public static extern int sytrs2(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* a, int lda,
+            int nrhs, /* const */ [In] float* a, int lda,
             int* ipiv, float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssytrs2_work")]
         public static extern int sytrs2(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* a,
+            int nrhs, /* const */ [In] float* a,
             int lda, int* ipiv,
             float* b, int ldb, float* work);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssytrs_rook")]
         public static extern int sytrs_rook(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* a, int lda,
+            int nrhs, /* const */ [In] float* a, int lda,
             int* ipiv, float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stbcon")]
         public static extern int tbcon(Layout layout, Norm norm, UpLoChar uplo, DiagChar diag,
-            int n, int kd, float* ab,
+            int n, int kd, /* const */ [In] float* ab,
             int ldab, float* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stbcon_work")]
         public static extern int tbcon(Layout layout, Norm norm, UpLoChar uplo,
             DiagChar diag, int n, int kd,
-            float* ab, int ldab, float* rcond,
+            /* const */ [In] float* ab, int ldab, float* rcond,
             float* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stbrfs")]
         public static extern int tbrfs(Layout layout, UpLoChar uplo, TransChar trans, DiagChar diag,
             int n, int kd, int nrhs,
-            float* ab, int ldab, float* b,
-            int ldb, float* x, int ldx,
+            /* const */ [In] float* ab, int ldab, /* const */ [In] float* b,
+            int ldb, /* const */ [In] float* x, int ldx,
             float* ferr, float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stbrfs_work")]
         public static extern int tbrfs(Layout layout, UpLoChar uplo, TransChar trans,
             DiagChar diag, int n, int kd,
-            int nrhs, float* ab,
-            int ldab, float* b, int ldb,
-            float* x, int ldx, float* ferr,
+            int nrhs, /* const */ [In] float* ab,
+            int ldab, /* const */ [In] float* b, int ldb,
+            /* const */ [In] float* x, int ldx, float* ferr,
             float* berr, float* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stbtrs")]
         public static extern int tbtrs(Layout layout, UpLoChar uplo, TransChar trans, DiagChar diag,
             int n, int kd, int nrhs,
-            float* ab, int ldab, float* b,
+            /* const */ [In] float* ab, int ldab, float* b,
             int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stfsm")]
         public static extern int tfsm(Layout layout, TransChar transr, char side, UpLoChar uplo,
             TransChar trans, DiagChar diag, int m, int n,
-            float alpha, float* a, float* b,
+            float alpha, /* const */ [In] float* a, float* b,
             int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stftri")]
@@ -5363,17 +5363,17 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stfttp")]
         public static extern int tfttp(Layout layout, TransChar transr, UpLoChar uplo,
-            int n, float* arf, float* ap);
+            int n, /* const */ [In] float* arf, float* ap);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stfttr")]
         public static extern int tfttr(Layout layout, TransChar transr, UpLoChar uplo,
-            int n, float* arf, float* a,
+            int n, /* const */ [In] float* arf, float* a,
             int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stgevc")]
         public static extern int tgevc(Layout layout, char side, char howmny,
             int* select, int n,
-            float* s, int lds, float* p,
+            /* const */ [In] float* s, int lds, /* const */ [In] float* p,
             int ldp, float* vl, int ldvl,
             float* vr, int ldvr, int mm,
             int* m);
@@ -5381,7 +5381,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stgevc_work")]
         public static extern int tgevc(Layout layout, char side, char howmny,
             int* select, int n,
-            float* s, int lds, float* p,
+            /* const */ [In] float* s, int lds, /* const */ [In] float* p,
             int ldp, float* vl, int ldvl,
             float* vr, int ldvr, int mm,
             int* m, float* work);
@@ -5446,60 +5446,60 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stgsna")]
         public static extern int tgsna(Layout layout, char job, char howmny,
             int* select, int n,
-            float* a, int lda, float* b,
-            int ldb, float* vl, int ldvl,
-            float* vr, int ldvr, float* s,
+            /* const */ [In] float* a, int lda, /* const */ [In] float* b,
+            int ldb, /* const */ [In] float* vl, int ldvl,
+            /* const */ [In] float* vr, int ldvr, float* s,
             float* dif, int mm, int* m);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stgsna_work")]
         public static extern int tgsna(Layout layout, char job, char howmny,
             int* select, int n,
-            float* a, int lda, float* b,
-            int ldb, float* vl,
-            int ldvl, float* vr,
+            /* const */ [In] float* a, int lda, /* const */ [In] float* b,
+            int ldb, /* const */ [In] float* vl,
+            int ldvl, /* const */ [In] float* vr,
             int ldvr, float* s, float* dif,
             int mm, int* m, float* work,
             int lwork, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stgsyl")]
         public static extern int tgsyl(Layout layout, TransChar trans, int ijob,
-            int m, int n, float* a,
-            int lda, float* b, int ldb,
-            float* c, int ldc, float* d,
-            int ldd, float* e, int lde,
+            int m, int n, /* const */ [In] float* a,
+            int lda, /* const */ [In] float* b, int ldb,
+            float* c, int ldc, /* const */ [In] float* d,
+            int ldd, /* const */ [In] float* e, int lde,
             float* f, int ldf, float* scale, float* dif);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stgsyl_work")]
         public static extern int tgsyl(Layout layout, TransChar trans, int ijob,
-            int m, int n, float* a,
-            int lda, float* b, int ldb,
-            float* c, int ldc, float* d,
-            int ldd, float* e, int lde,
+            int m, int n, /* const */ [In] float* a,
+            int lda, /* const */ [In] float* b, int ldb,
+            float* c, int ldc, /* const */ [In] float* d,
+            int ldd, /* const */ [In] float* e, int lde,
             float* f, int ldf, float* scale,
             float* dif, float* work, int lwork,
             int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stpcon")]
         public static extern int tpcon(Layout layout, Norm norm, UpLoChar uplo, DiagChar diag,
-            int n, float* ap, float* rcond);
+            int n, /* const */ [In] float* ap, float* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stpcon_work")]
         public static extern int tpcon(Layout layout, Norm norm, UpLoChar uplo,
-            DiagChar diag, int n, float* ap,
+            DiagChar diag, int n, /* const */ [In] float* ap,
             float* rcond, float* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stpmqrt")]
         public static extern int tpmqrt(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            int l, int nb, float* v,
-            int ldv, float* t, int ldt,
+            int l, int nb, /* const */ [In] float* v,
+            int ldv, /* const */ [In] float* t, int ldt,
             float* a, int lda, float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stpmqrt_work")]
         public static extern int tpmqrt(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            int l, int nb, float* v,
-            int ldv, float* t, int ldt,
+            int l, int nb, /* const */ [In] float* v,
+            int ldv, /* const */ [In] float* t, int ldt,
             float* a, int lda, float* b,
             int ldb, float* work);
 
@@ -5524,30 +5524,30 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stprfb")]
         public static extern int tprfb(Layout layout, char side, TransChar trans, char direct,
             char storev, int m, int n,
-            int k, int l, float* v,
-            int ldv, float* t, int ldt,
+            int k, int l, /* const */ [In] float* v,
+            int ldv, /* const */ [In] float* t, int ldt,
             float* a, int lda, float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stprfb_work")]
         public static extern int tprfb(Layout layout, char side, TransChar trans,
             char direct, char storev, int m,
             int n, int k, int l,
-            float* v, int ldv, float* t,
+            /* const */ [In] float* v, int ldv, /* const */ [In] float* t,
             int ldt, float* a, int lda,
             float* b, int ldb, float* work,
             int ldwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stprfs")]
         public static extern int tprfs(Layout layout, UpLoChar uplo, TransChar trans, DiagChar diag,
-            int n, int nrhs, float* ap,
-            float* b, int ldb, float* x,
+            int n, int nrhs, /* const */ [In] float* ap,
+            /* const */ [In] float* b, int ldb, /* const */ [In] float* x,
             int ldx, float* ferr, float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stprfs_work")]
         public static extern int tprfs(Layout layout, UpLoChar uplo, TransChar trans,
             DiagChar diag, int n, int nrhs,
-            float* ap, float* b, int ldb,
-            float* x, int ldx, float* ferr,
+            /* const */ [In] float* ap, /* const */ [In] float* b, int ldb,
+            /* const */ [In] float* x, int ldx, float* ferr,
             float* berr, float* work, int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stptri")]
@@ -5556,31 +5556,31 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stptrs")]
         public static extern int tptrs(Layout layout, UpLoChar uplo, TransChar trans, DiagChar diag,
-            int n, int nrhs, float* ap,
+            int n, int nrhs, /* const */ [In] float* ap,
             float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stpttf")]
         public static extern int tpttf(Layout layout, TransChar transr, UpLoChar uplo,
-            int n, float* ap, float* arf);
+            int n, /* const */ [In] float* ap, float* arf);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stpttr")]
         public static extern int tpttr(Layout layout, UpLoChar uplo, int n,
-            float* ap, float* a, int lda);
+            /* const */ [In] float* ap, float* a, int lda);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_strcon")]
         public static extern int trcon(Layout layout, Norm norm, UpLoChar uplo, DiagChar diag,
-            int n, float* a, int lda,
+            int n, /* const */ [In] float* a, int lda,
             float* rcond);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_strcon_work")]
         public static extern int trcon(Layout layout, Norm norm, UpLoChar uplo,
-            DiagChar diag, int n, float* a,
+            DiagChar diag, int n, /* const */ [In] float* a,
             int lda, float* rcond, float* work,
             int* iwork);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_strevc")]
         public static extern int trevc(Layout layout, char side, char howmny,
-            int* select, int n, float* t,
+            int* select, int n, /* const */ [In] float* t,
             int ldt, float* vl, int ldvl,
             float* vr, int ldvr, int mm,
             int* m);
@@ -5588,7 +5588,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_strevc_work")]
         public static extern int trevc(Layout layout, char side, char howmny,
             int* select, int n,
-            float* t, int ldt, float* vl,
+            /* const */ [In] float* t, int ldt, float* vl,
             int ldvl, float* vr, int ldvr,
             int mm, int* m, float* work);
 
@@ -5605,16 +5605,16 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_strrfs")]
         public static extern int trrfs(Layout layout, UpLoChar uplo, TransChar trans, DiagChar diag,
-            int n, int nrhs, float* a,
-            int lda, float* b, int ldb,
-            float* x, int ldx, float* ferr,
+            int n, int nrhs, /* const */ [In] float* a,
+            int lda, /* const */ [In] float* b, int ldb,
+            /* const */ [In] float* x, int ldx, float* ferr,
             float* berr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_strrfs_work")]
         public static extern int trrfs(Layout layout, UpLoChar uplo, TransChar trans,
             DiagChar diag, int n, int nrhs,
-            float* a, int lda, float* b,
-            int ldb, float* x, int ldx,
+            /* const */ [In] float* a, int lda, /* const */ [In] float* b,
+            int ldb, /* const */ [In] float* x, int ldx,
             float* ferr, float* berr, float* work,
             int* iwork);
 
@@ -5636,15 +5636,15 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_strsna")]
         public static extern int trsna(Layout layout, char job, char howmny,
             int* select, int n,
-            float* t, int ldt, float* vl,
-            int ldvl, float* vr, int ldvr,
+            /* const */ [In] float* t, int ldt, /* const */ [In] float* vl,
+            int ldvl, /* const */ [In] float* vr, int ldvr,
             float* s, float* sep, int mm, int* m);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_strsna_work")]
         public static extern int trsna(Layout layout, char job, char howmny,
             int* select, int n,
-            float* t, int ldt, float* vl,
-            int ldvl, float* vr,
+            /* const */ [In] float* t, int ldt, /* const */ [In] float* vl,
+            int ldvl, /* const */ [In] float* vr,
             int ldvr, float* s, float* sep,
             int mm, int* m, float* work,
             int ldwork, int* iwork);
@@ -5652,7 +5652,7 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_strsyl")]
         public static extern int trsyl(Layout layout, char trana, char tranb,
             int isgn, int m, int n,
-            float* a, int lda, float* b,
+            /* const */ [In] float* a, int lda, /* const */ [In] float* b,
             int ldb, float* c, int ldc,
             float* scale);
 
@@ -5662,17 +5662,17 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_strtrs")]
         public static extern int trtrs(Layout layout, UpLoChar uplo, TransChar trans, DiagChar diag,
-            int n, int nrhs, float* a,
+            int n, int nrhs, /* const */ [In] float* a,
             int lda, float* b, int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_strttf")]
         public static extern int trttf(Layout layout, TransChar transr, UpLoChar uplo,
-            int n, float* a, int lda,
+            int n, /* const */ [In] float* a, int lda,
             float* arf);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_strttp")]
         public static extern int trttp(Layout layout, UpLoChar uplo, int n,
-            float* a, int lda, float* ap);
+            /* const */ [In] float* a, int lda, float* ap);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_stzrzf")]
         public static extern int tzrzf(Layout layout, int m, int n,
@@ -5705,13 +5705,13 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsytrs_aa")]
         public static extern int sytrs_aa(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* a, int lda,
+            int nrhs, /* const */ [In] double* a, int lda,
             int* ipiv, double* b,
             int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dsytrs_aa_work")]
         public static extern int sytrs_aa(Layout layout, UpLoChar uplo, int n,
-            int nrhs, double* a,
+            int nrhs, /* const */ [In] double* a,
             int lda, int* ipiv,
             double* b, int ldb, double* work,
             int lwork);
@@ -5738,13 +5738,13 @@ public static partial class Lapack
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssytrs_aa")]
         public static extern int sytrs_aa(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* a, int lda,
+            int nrhs, /* const */ [In] float* a, int lda,
             int* ipiv, float* b,
             int ldb);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_ssytrs_aa_work")]
         public static extern int sytrs_aa(Layout layout, UpLoChar uplo, int n,
-            int nrhs, float* a,
+            int nrhs, /* const */ [In] float* a,
             int lda, int* ipiv,
             float* b, int ldb, float* work,
             int lwork);
@@ -5752,15 +5752,15 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgemqr")]
         public static extern int gemqr(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            double* a, int lda,
-            double* t, int tsize, double* c,
+            /* const */ [In] double* a, int lda,
+            /* const */ [In] double* t, int tsize, double* c,
             int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgemqr_work")]
         public static extern int gemqr(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            double* a, int lda,
-            double* t, int tsize,
+            /* const */ [In] double* a, int lda,
+            /* const */ [In] double* t, int tsize,
             double* c, int ldc, double* work,
             int lwork);
 
@@ -5778,14 +5778,14 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgemqr")]
         public static extern int gemqr(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            float* a, int lda, float* t,
+            /* const */ [In] float* a, int lda, /* const */ [In] float* t,
             int tsize, float* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgemqr_work")]
         public static extern int gemqr(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            float* a, int lda,
-            float* t, int tsize,
+            /* const */ [In] float* a, int lda,
+            /* const */ [In] float* t, int tsize,
             float* c, int ldc, float* work,
             int lwork);
 
@@ -5814,14 +5814,14 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgemlq")]
         public static extern int gemlq(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            double* a, int lda, double* t,
+            /* const */ [In] double* a, int lda, /* const */ [In] double* t,
             int tsize, double* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_dgemlq_work")]
         public static extern int gemlq(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            double* a, int lda,
-            double* t, int tsize, double* c,
+            /* const */ [In] double* a, int lda,
+            /* const */ [In] double* t, int tsize, double* c,
             int ldc, double* work,
             int lwork);
 
@@ -5839,13 +5839,13 @@ public static partial class Lapack
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgemlq")]
         public static extern int gemlq(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            float* a, int lda, float* t,
+            /* const */ [In] float* a, int lda, /* const */ [In] float* t,
             int tsize, float* c, int ldc);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "LAPACKE_sgemlq_work")]
         public static extern int gemlq(Layout layout, char side, TransChar trans,
             int m, int n, int k,
-            float* a, int lda, float* t,
+            /* const */ [In] float* a, int lda, /* const */ [In] float* t,
             int tsize, float* c, int ldc,
             float* work, int lwork);
 

--- a/MKL.NET/Vml.cs
+++ b/MKL.NET/Vml.cs
@@ -24,1571 +24,1571 @@ public static partial class Vml
     public unsafe static class Unsafe
     {
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAbs")]
-        public static extern void Abs(int n, float* a, float* r);
+        public static extern void Abs(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAbs")]
-        public static extern void Abs(int n, double* a, double* r);
+        public static extern void Abs(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAbs")]
-        public static extern void Abs(int n, float* a, float* r, VmlMode mode);
+        public static extern void Abs(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAbs")]
-        public static extern void Abs(int n, double* a, double* r, VmlMode mode);
+        public static extern void Abs(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAdd")]
-        public static extern void Add(int n, float* a, float* b, float* r);
+        public static extern void Add(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAdd")]
-        public static extern void Add(int n, double* a, double* b, double* r);
+        public static extern void Add(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAdd")]
-        public static extern void Add(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void Add(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAdd")]
-        public static extern void Add(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void Add(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSub")]
-        public static extern void Sub(int n, float* a, float* b, float* r);
+        public static extern void Sub(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSub")]
-        public static extern void Sub(int n, double* a, double* b, double* r);
+        public static extern void Sub(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSub")]
-        public static extern void Sub(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void Sub(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSub")]
-        public static extern void Sub(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void Sub(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsInv")]
-        public static extern void Inv(int n, float* a, float* r);
+        public static extern void Inv(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdInv")]
-        public static extern void Inv(int n, double* a, double* r);
+        public static extern void Inv(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsInv")]
-        public static extern void Inv(int n, float* a, float* r, VmlMode mode);
+        public static extern void Inv(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdInv")]
-        public static extern void Inv(int n, double* a, double* r, VmlMode mode);
+        public static extern void Inv(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSqrt")]
-        public static extern void Sqrt(int n, float* a, float* r);
+        public static extern void Sqrt(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSqrt")]
-        public static extern void Sqrt(int n, double* a, double* r);
+        public static extern void Sqrt(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSqrt")]
-        public static extern void Sqrt(int n, float* a, float* r, VmlMode mode);
+        public static extern void Sqrt(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSqrt")]
-        public static extern void Sqrt(int n, double* a, double* r, VmlMode mode);
+        public static extern void Sqrt(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsInvSqrt")]
-        public static extern void InvSqrt(int n, float* a, float* r);
+        public static extern void InvSqrt(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdInvSqrt")]
-        public static extern void InvSqrt(int n, double* a, double* r);
+        public static extern void InvSqrt(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsInvSqrt")]
-        public static extern void InvSqrt(int n, float* a, float* r, VmlMode mode);
+        public static extern void InvSqrt(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdInvSqrt")]
-        public static extern void InvSqrt(int n, double* a, double* r, VmlMode mode);
+        public static extern void InvSqrt(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCbrt")]
-        public static extern void Cbrt(int n, float* a, float* r);
+        public static extern void Cbrt(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCbrt")]
-        public static extern void Cbrt(int n, double* a, double* r);
+        public static extern void Cbrt(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCbrt")]
-        public static extern void Cbrt(int n, float* a, float* r, VmlMode mode);
+        public static extern void Cbrt(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCbrt")]
-        public static extern void Cbrt(int n, double* a, double* r, VmlMode mode);
+        public static extern void Cbrt(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsInvCbrt")]
-        public static extern void InvCbrt(int n, float* a, float* r);
+        public static extern void InvCbrt(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdInvCbrt")]
-        public static extern void InvCbrt(int n, double* a, double* r);
+        public static extern void InvCbrt(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsInvCbrt")]
-        public static extern void InvCbrt(int n, float* a, float* r, VmlMode mode);
+        public static extern void InvCbrt(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdInvCbrt")]
-        public static extern void InvCbrt(int n, double* a, double* r, VmlMode mode);
+        public static extern void InvCbrt(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSqr")]
-        public static extern void Sqr(int n, float* a, float* r);
+        public static extern void Sqr(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSqr")]
-        public static extern void Sqr(int n, double* a, double* r);
+        public static extern void Sqr(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSqr")]
-        public static extern void Sqr(int n, float* a, float* r, VmlMode mode);
+        public static extern void Sqr(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSqr")]
-        public static extern void Sqr(int n, double* a, double* r, VmlMode mode);
+        public static extern void Sqr(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsExp")]
-        public static extern void Exp(int n, float* a, float* r);
+        public static extern void Exp(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdExp")]
-        public static extern void Exp(int n, double* a, double* r);
+        public static extern void Exp(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsExp")]
-        public static extern void Exp(int n, float* a, float* r, VmlMode mode);
+        public static extern void Exp(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdExp")]
-        public static extern void Exp(int n, double* a, double* r, VmlMode mode);
+        public static extern void Exp(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsExp2")]
-        public static extern void Exp2(int n, float* a, float* r);
+        public static extern void Exp2(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdExp2")]
-        public static extern void Exp2(int n, double* a, double* r);
+        public static extern void Exp2(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsExp2")]
-        public static extern void Exp2(int n, float* a, float* r, VmlMode mode);
+        public static extern void Exp2(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdExp2")]
-        public static extern void Exp2(int n, double* a, double* r, VmlMode mode);
+        public static extern void Exp2(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsExp10")]
-        public static extern void Exp10(int n, float* a, float* r);
+        public static extern void Exp10(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdExp10")]
-        public static extern void Exp10(int n, double* a, double* r);
+        public static extern void Exp10(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsExp10")]
-        public static extern void Exp10(int n, float* a, float* r, VmlMode mode);
+        public static extern void Exp10(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdExp10")]
-        public static extern void Exp10(int n, double* a, double* r, VmlMode mode);
+        public static extern void Exp10(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsExpm1")]
-        public static extern void Expm1(int n, float* a, float* r);
+        public static extern void Expm1(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdExpm1")]
-        public static extern void Expm1(int n, double* a, double* r);
+        public static extern void Expm1(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsExpm1")]
-        public static extern void Expm1(int n, float* a, float* r, VmlMode mode);
+        public static extern void Expm1(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdExpm1")]
-        public static extern void Expm1(int n, double* a, double* r, VmlMode mode);
+        public static extern void Expm1(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsLn")]
-        public static extern void Ln(int n, float* a, float* r);
+        public static extern void Ln(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdLn")]
-        public static extern void Ln(int n, double* a, double* r);
+        public static extern void Ln(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsLn")]
-        public static extern void Ln(int n, float* a, float* r, VmlMode mode);
+        public static extern void Ln(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdLn")]
-        public static extern void Ln(int n, double* a, double* r, VmlMode mode);
+        public static extern void Ln(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsLog2")]
-        public static extern void Log2(int n, float* a, float* r);
+        public static extern void Log2(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdLog2")]
-        public static extern void Log2(int n, double* a, double* r);
+        public static extern void Log2(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsLog2")]
-        public static extern void Log2(int n, float* a, float* r, VmlMode mode);
+        public static extern void Log2(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdLog2")]
-        public static extern void Log2(int n, double* a, double* r, VmlMode mode);
+        public static extern void Log2(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsLog10")]
-        public static extern void Log10(int n, float* a, float* r);
+        public static extern void Log10(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdLog10")]
-        public static extern void Log10(int n, double* a, double* r);
+        public static extern void Log10(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsLog10")]
-        public static extern void Log10(int n, float* a, float* r, VmlMode mode);
+        public static extern void Log10(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdLog10")]
-        public static extern void Log10(int n, double* a, double* r, VmlMode mode);
+        public static extern void Log10(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsLog1p")]
-        public static extern void Log1p(int n, float* a, float* r);
+        public static extern void Log1p(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdLog1p")]
-        public static extern void Log1p(int n, double* a, double* r);
+        public static extern void Log1p(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsLog1p")]
-        public static extern void Log1p(int n, float* a, float* r, VmlMode mode);
+        public static extern void Log1p(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdLog1p")]
-        public static extern void Log1p(int n, double* a, double* r, VmlMode mode);
+        public static extern void Log1p(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsLogb")]
-        public static extern void Logb(int n, float* a, float* r);
+        public static extern void Logb(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdLogb")]
-        public static extern void Logb(int n, double* a, double* r);
+        public static extern void Logb(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsLogb")]
-        public static extern void Logb(int n, float* a, float* r, VmlMode mode);
+        public static extern void Logb(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdLogb")]
-        public static extern void Logb(int n, double* a, double* r, VmlMode mode);
+        public static extern void Logb(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCos")]
-        public static extern void Cos(int n, float* a, float* r);
+        public static extern void Cos(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCos")]
-        public static extern void Cos(int n, double* a, double* r);
+        public static extern void Cos(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCos")]
-        public static extern void Cos(int n, float* a, float* r, VmlMode mode);
+        public static extern void Cos(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCos")]
-        public static extern void Cos(int n, double* a, double* r, VmlMode mode);
+        public static extern void Cos(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSin")]
-        public static extern void Sin(int n, float* a, float* r);
+        public static extern void Sin(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSin")]
-        public static extern void Sin(int n, double* a, double* r);
+        public static extern void Sin(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSin")]
-        public static extern void Sin(int n, float* a, float* r, VmlMode mode);
+        public static extern void Sin(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSin")]
-        public static extern void Sin(int n, double* a, double* r, VmlMode mode);
+        public static extern void Sin(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsTan")]
-        public static extern void Tan(int n, float* a, float* r);
+        public static extern void Tan(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdTan")]
-        public static extern void Tan(int n, double* a, double* r);
+        public static extern void Tan(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsTan")]
-        public static extern void Tan(int n, float* a, float* r, VmlMode mode);
+        public static extern void Tan(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdTan")]
-        public static extern void Tan(int n, double* a, double* r, VmlMode mode);
+        public static extern void Tan(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCospi")]
-        public static extern void Cospi(int n, float* a, float* r);
+        public static extern void Cospi(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCospi")]
-        public static extern void Cospi(int n, double* a, double* r);
+        public static extern void Cospi(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCospi")]
-        public static extern void Cospi(int n, float* a, float* r, VmlMode mode);
+        public static extern void Cospi(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCospi")]
-        public static extern void Cospi(int n, double* a, double* r, VmlMode mode);
+        public static extern void Cospi(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSinpi")]
-        public static extern void Sinpi(int n, float* a, float* r);
+        public static extern void Sinpi(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSinpi")]
-        public static extern void Sinpi(int n, double* a, double* r);
+        public static extern void Sinpi(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSinpi")]
-        public static extern void Sinpi(int n, float* a, float* r, VmlMode mode);
+        public static extern void Sinpi(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSinpi")]
-        public static extern void Sinpi(int n, double* a, double* r, VmlMode mode);
+        public static extern void Sinpi(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsTanpi")]
-        public static extern void Tanpi(int n, float* a, float* r);
+        public static extern void Tanpi(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdTanpi")]
-        public static extern void Tanpi(int n, double* a, double* r);
+        public static extern void Tanpi(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsTanpi")]
-        public static extern void Tanpi(int n, float* a, float* r, VmlMode mode);
+        public static extern void Tanpi(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdTanpi")]
-        public static extern void Tanpi(int n, double* a, double* r, VmlMode mode);
+        public static extern void Tanpi(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCosd")]
-        public static extern void Cosd(int n, float* a, float* r);
+        public static extern void Cosd(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCosd")]
-        public static extern void Cosd(int n, double* a, double* r);
+        public static extern void Cosd(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCosd")]
-        public static extern void Cosd(int n, float* a, float* r, VmlMode mode);
+        public static extern void Cosd(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCosd")]
-        public static extern void Cosd(int n, double* a, double* r, VmlMode mode);
+        public static extern void Cosd(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSind")]
-        public static extern void Sind(int n, float* a, float* r);
+        public static extern void Sind(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSind")]
-        public static extern void Sind(int n, double* a, double* r);
+        public static extern void Sind(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSind")]
-        public static extern void Sind(int n, float* a, float* r, VmlMode mode);
+        public static extern void Sind(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSind")]
-        public static extern void Sind(int n, double* a, double* r, VmlMode mode);
+        public static extern void Sind(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsTand")]
-        public static extern void Tand(int n, float* a, float* r);
+        public static extern void Tand(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdTand")]
-        public static extern void Tand(int n, double* a, double* r);
+        public static extern void Tand(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsTand")]
-        public static extern void Tand(int n, float* a, float* r, VmlMode mode);
+        public static extern void Tand(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdTand")]
-        public static extern void Tand(int n, double* a, double* r, VmlMode mode);
+        public static extern void Tand(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCosh")]
-        public static extern void Cosh(int n, float* a, float* r);
+        public static extern void Cosh(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCosh")]
-        public static extern void Cosh(int n, double* a, double* r);
+        public static extern void Cosh(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCosh")]
-        public static extern void Cosh(int n, float* a, float* r, VmlMode mode);
+        public static extern void Cosh(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCosh")]
-        public static extern void Cosh(int n, double* a, double* r, VmlMode mode);
+        public static extern void Cosh(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSinh")]
-        public static extern void Sinh(int n, float* a, float* r);
+        public static extern void Sinh(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSinh")]
-        public static extern void Sinh(int n, double* a, double* r);
+        public static extern void Sinh(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSinh")]
-        public static extern void Sinh(int n, float* a, float* r, VmlMode mode);
+        public static extern void Sinh(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSinh")]
-        public static extern void Sinh(int n, double* a, double* r, VmlMode mode);
+        public static extern void Sinh(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsTanh")]
-        public static extern void Tanh(int n, float* a, float* r);
+        public static extern void Tanh(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdTanh")]
-        public static extern void Tanh(int n, double* a, double* r);
+        public static extern void Tanh(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsTanh")]
-        public static extern void Tanh(int n, float* a, float* r, VmlMode mode);
+        public static extern void Tanh(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdTanh")]
-        public static extern void Tanh(int n, double* a, double* r, VmlMode mode);
+        public static extern void Tanh(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAcos")]
-        public static extern void Acos(int n, float* a, float* r);
+        public static extern void Acos(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAcos")]
-        public static extern void Acos(int n, double* a, double* r);
+        public static extern void Acos(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAcos")]
-        public static extern void Acos(int n, float* a, float* r, VmlMode mode);
+        public static extern void Acos(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAcos")]
-        public static extern void Acos(int n, double* a, double* r, VmlMode mode);
+        public static extern void Acos(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAsin")]
-        public static extern void Asin(int n, float* a, float* r);
+        public static extern void Asin(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAsin")]
-        public static extern void Asin(int n, double* a, double* r);
+        public static extern void Asin(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAsin")]
-        public static extern void Asin(int n, float* a, float* r, VmlMode mode);
+        public static extern void Asin(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAsin")]
-        public static extern void Asin(int n, double* a, double* r, VmlMode mode);
+        public static extern void Asin(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAtan")]
-        public static extern void Atan(int n, float* a, float* r);
+        public static extern void Atan(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAtan")]
-        public static extern void Atan(int n, double* a, double* r);
+        public static extern void Atan(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAtan")]
-        public static extern void Atan(int n, float* a, float* r, VmlMode mode);
+        public static extern void Atan(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAtan")]
-        public static extern void Atan(int n, double* a, double* r, VmlMode mode);
+        public static extern void Atan(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAcospi")]
-        public static extern void Acospi(int n, float* a, float* r);
+        public static extern void Acospi(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAcospi")]
-        public static extern void Acospi(int n, double* a, double* r);
+        public static extern void Acospi(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAcospi")]
-        public static extern void Acospi(int n, float* a, float* r, VmlMode mode);
+        public static extern void Acospi(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAcospi")]
-        public static extern void Acospi(int n, double* a, double* r, VmlMode mode);
+        public static extern void Acospi(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAsinpi")]
-        public static extern void Asinpi(int n, float* a, float* r);
+        public static extern void Asinpi(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAsinpi")]
-        public static extern void Asinpi(int n, double* a, double* r);
+        public static extern void Asinpi(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAsinpi")]
-        public static extern void Asinpi(int n, float* a, float* r, VmlMode mode);
+        public static extern void Asinpi(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAsinpi")]
-        public static extern void Asinpi(int n, double* a, double* r, VmlMode mode);
+        public static extern void Asinpi(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAtanpi")]
-        public static extern void Atanpi(int n, float* a, float* r);
+        public static extern void Atanpi(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAtanpi")]
-        public static extern void Atanpi(int n, double* a, double* r);
+        public static extern void Atanpi(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAtanpi")]
-        public static extern void Atanpi(int n, float* a, float* r, VmlMode mode);
+        public static extern void Atanpi(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAtanpi")]
-        public static extern void Atanpi(int n, double* a, double* r, VmlMode mode);
+        public static extern void Atanpi(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAcosh")]
-        public static extern void Acosh(int n, float* a, float* r);
+        public static extern void Acosh(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAcosh")]
-        public static extern void Acosh(int n, double* a, double* r);
+        public static extern void Acosh(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAcosh")]
-        public static extern void Acosh(int n, float* a, float* r, VmlMode mode);
+        public static extern void Acosh(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAcosh")]
-        public static extern void Acosh(int n, double* a, double* r, VmlMode mode);
+        public static extern void Acosh(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAsinh")]
-        public static extern void Asinh(int n, float* a, float* r);
+        public static extern void Asinh(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAsinh")]
-        public static extern void Asinh(int n, double* a, double* r);
+        public static extern void Asinh(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAsinh")]
-        public static extern void Asinh(int n, float* a, float* r, VmlMode mode);
+        public static extern void Asinh(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAsinh")]
-        public static extern void Asinh(int n, double* a, double* r, VmlMode mode);
+        public static extern void Asinh(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAtanh")]
-        public static extern void Atanh(int n, float* a, float* r);
+        public static extern void Atanh(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAtanh")]
-        public static extern void Atanh(int n, double* a, double* r);
+        public static extern void Atanh(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAtanh")]
-        public static extern void Atanh(int n, float* a, float* r, VmlMode mode);
+        public static extern void Atanh(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAtanh")]
-        public static extern void Atanh(int n, double* a, double* r, VmlMode mode);
+        public static extern void Atanh(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsErf")]
-        public static extern void Erf(int n, float* a, float* r);
+        public static extern void Erf(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdErf")]
-        public static extern void Erf(int n, double* a, double* r);
+        public static extern void Erf(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsErf")]
-        public static extern void Erf(int n, float* a, float* r, VmlMode mode);
+        public static extern void Erf(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdErf")]
-        public static extern void Erf(int n, double* a, double* r, VmlMode mode);
+        public static extern void Erf(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsErfInv")]
-        public static extern void ErfInv(int n, float* a, float* r);
+        public static extern void ErfInv(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdErfInv")]
-        public static extern void ErfInv(int n, double* a, double* r);
+        public static extern void ErfInv(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsErfInv")]
-        public static extern void ErfInv(int n, float* a, float* r, VmlMode mode);
+        public static extern void ErfInv(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdErfInv")]
-        public static extern void ErfInv(int n, double* a, double* r, VmlMode mode);
+        public static extern void ErfInv(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsHypot")]
-        public static extern void Hypot(int n, float* a, float* b, float* r);
+        public static extern void Hypot(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdHypot")]
-        public static extern void Hypot(int n, double* a, double* b, double* r);
+        public static extern void Hypot(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsHypot")]
-        public static extern void Hypot(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void Hypot(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdHypot")]
-        public static extern void Hypot(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void Hypot(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsErfc")]
-        public static extern void Erfc(int n, float* a, float* r);
+        public static extern void Erfc(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdErfc")]
-        public static extern void Erfc(int n, double* a, double* r);
+        public static extern void Erfc(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsErfc")]
-        public static extern void Erfc(int n, float* a, float* r, VmlMode mode);
+        public static extern void Erfc(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdErfc")]
-        public static extern void Erfc(int n, double* a, double* r, VmlMode mode);
+        public static extern void Erfc(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsErfcInv")]
-        public static extern void ErfcInv(int n, float* a, float* r);
+        public static extern void ErfcInv(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdErfcInv")]
-        public static extern void ErfcInv(int n, double* a, double* r);
+        public static extern void ErfcInv(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsErfcInv")]
-        public static extern void ErfcInv(int n, float* a, float* r, VmlMode mode);
+        public static extern void ErfcInv(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdErfcInv")]
-        public static extern void ErfcInv(int n, double* a, double* r, VmlMode mode);
+        public static extern void ErfcInv(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCdfNorm")]
-        public static extern void CdfNorm(int n, float* a, float* r);
+        public static extern void CdfNorm(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCdfNorm")]
-        public static extern void CdfNorm(int n, double* a, double* r);
+        public static extern void CdfNorm(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCdfNorm")]
-        public static extern void CdfNorm(int n, float* a, float* r, VmlMode mode);
+        public static extern void CdfNorm(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCdfNorm")]
-        public static extern void CdfNorm(int n, double* a, double* r, VmlMode mode);
+        public static extern void CdfNorm(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCdfNormInv")]
-        public static extern void CdfNormInv(int n, float* a, float* r);
+        public static extern void CdfNormInv(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCdfNormInv")]
-        public static extern void CdfNormInv(int n, double* a, double* r);
+        public static extern void CdfNormInv(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCdfNormInv")]
-        public static extern void CdfNormInv(int n, float* a, float* r, VmlMode mode);
+        public static extern void CdfNormInv(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCdfNormInv")]
-        public static extern void CdfNormInv(int n, double* a, double* r, VmlMode mode);
+        public static extern void CdfNormInv(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsLGamma")]
-        public static extern void LGamma(int n, float* a, float* r);
+        public static extern void LGamma(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdLGamma")]
-        public static extern void LGamma(int n, double* a, double* r);
+        public static extern void LGamma(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsLGamma")]
-        public static extern void LGamma(int n, float* a, float* r, VmlMode mode);
+        public static extern void LGamma(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdLGamma")]
-        public static extern void LGamma(int n, double* a, double* r, VmlMode mode);
+        public static extern void LGamma(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsTGamma")]
-        public static extern void TGamma(int n, float* a, float* r);
+        public static extern void TGamma(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdTGamma")]
-        public static extern void TGamma(int n, double* a, double* r);
+        public static extern void TGamma(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsTGamma")]
-        public static extern void TGamma(int n, float* a, float* r, VmlMode mode);
+        public static extern void TGamma(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdTGamma")]
-        public static extern void TGamma(int n, double* a, double* r, VmlMode mode);
+        public static extern void TGamma(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAtan2")]
-        public static extern void Atan2(int n, float* a, float* b, float* r);
+        public static extern void Atan2(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAtan2")]
-        public static extern void Atan2(int n, double* a, double* b, double* r);
+        public static extern void Atan2(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAtan2")]
-        public static extern void Atan2(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void Atan2(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAtan2")]
-        public static extern void Atan2(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void Atan2(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAtan2pi")]
-        public static extern void Atan2pi(int n, float* a, float* b, float* r);
+        public static extern void Atan2pi(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAtan2pi")]
-        public static extern void Atan2pi(int n, double* a, double* b, double* r);
+        public static extern void Atan2pi(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAtan2pi")]
-        public static extern void Atan2pi(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void Atan2pi(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAtan2pi")]
-        public static extern void Atan2pi(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void Atan2pi(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsMul")]
-        public static extern void Mul(int n, float* a, float* b, float* r);
+        public static extern void Mul(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdMul")]
-        public static extern void Mul(int n, double* a, double* b, double* r);
+        public static extern void Mul(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsMul")]
-        public static extern void Mul(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void Mul(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdMul")]
-        public static extern void Mul(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void Mul(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsDiv")]
-        public static extern void Div(int n, float* a, float* b, float* r);
+        public static extern void Div(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdDiv")]
-        public static extern void Div(int n, double* a, double* b, double* r);
+        public static extern void Div(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsDiv")]
-        public static extern void Div(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void Div(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdDiv")]
-        public static extern void Div(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void Div(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsPow")]
-        public static extern void Pow(int n, float* a, float* b, float* r);
+        public static extern void Pow(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdPow")]
-        public static extern void Pow(int n, double* a, double* b, double* r);
+        public static extern void Pow(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsPow")]
-        public static extern void Pow(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void Pow(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdPow")]
-        public static extern void Pow(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void Pow(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsPow3o2")]
-        public static extern void Pow3o2(int n, float* a, float* r);
+        public static extern void Pow3o2(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdPow3o2")]
-        public static extern void Pow3o2(int n, double* a, double* r);
+        public static extern void Pow3o2(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsPow3o2")]
-        public static extern void Pow3o2(int n, float* a, float* r, VmlMode mode);
+        public static extern void Pow3o2(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdPow3o2")]
-        public static extern void Pow3o2(int n, double* a, double* r, VmlMode mode);
+        public static extern void Pow3o2(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsPow2o3")]
-        public static extern void Pow2o3(int n, float* a, float* r);
+        public static extern void Pow2o3(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdPow2o3")]
-        public static extern void Pow2o3(int n, double* a, double* r);
+        public static extern void Pow2o3(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsPow2o3")]
-        public static extern void Pow2o3(int n, float* a, float* r, VmlMode mode);
+        public static extern void Pow2o3(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdPow2o3")]
-        public static extern void Pow2o3(int n, double* a, double* r, VmlMode mode);
+        public static extern void Pow2o3(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsPowx")]
-        public static extern void Powx(int n, float* a, float b, float* r);
+        public static extern void Powx(int n, /* const */ [In] float* a, float b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdPowx")]
-        public static extern void Powx(int n, double* a, double b, double* r);
+        public static extern void Powx(int n, /* const */ [In] double* a, double b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsPowx")]
-        public static extern void Powx(int n, float* a, float b, float* r, VmlMode mode);
+        public static extern void Powx(int n, /* const */ [In] float* a, float b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdPowx")]
-        public static extern void Powx(int n, double* a, double b, double* r, VmlMode mode);
+        public static extern void Powx(int n, /* const */ [In] double* a, double b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsPowr")]
-        public static extern void Powr(int n, float* a, float* b, float* r);
+        public static extern void Powr(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdPowr")]
-        public static extern void Powr(int n, double* a, double* b, double* r);
+        public static extern void Powr(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsPowr")]
-        public static extern void Powr(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void Powr(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdPowr")]
-        public static extern void Powr(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void Powr(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSinCos")]
-        public static extern void SinCos(int n, float* a, float* r1, float* r2);
+        public static extern void SinCos(int n, /* const */ [In] float* a, float* r1, float* r2);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSinCos")]
-        public static extern void SinCos(int n, double* a, double* r1, double* r2);
+        public static extern void SinCos(int n, /* const */ [In] double* a, double* r1, double* r2);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSinCos")]
-        public static extern void SinCos(int n, float* a, float* r1, float* r2, VmlMode mode);
+        public static extern void SinCos(int n, /* const */ [In] float* a, float* r1, float* r2, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSinCos")]
-        public static extern void SinCos(int n, double* a, double* r1, double* r2, VmlMode mode);
+        public static extern void SinCos(int n, /* const */ [In] double* a, double* r1, double* r2, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsLinearFrac")]
-        public static extern void LinearFrac(int n, float* a, float* b, float scalea, float shifta, float scaleb, float shiftb, float* r);
+        public static extern void LinearFrac(int n, /* const */ [In] float* a, /* const */ [In] float* b, float scalea, float shifta, float scaleb, float shiftb, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdLinearFrac")]
-        public static extern void LinearFrac(int n, double* a, double* b, double scalea, double shifta, double scaleb, double shiftb, double* r);
+        public static extern void LinearFrac(int n, /* const */ [In] double* a, /* const */ [In] double* b, double scalea, double shifta, double scaleb, double shiftb, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsLinearFrac")]
-        public static extern void LinearFrac(int n, float* a, float* b, float scalea, float shifta, float scaleb, float shiftb, float* r, VmlMode mode);
+        public static extern void LinearFrac(int n, /* const */ [In] float* a, /* const */ [In] float* b, float scalea, float shifta, float scaleb, float shiftb, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdLinearFrac")]
-        public static extern void LinearFrac(int n, double* a, double* b, double scalea, double shifta, double scaleb, double shiftb, double* r, VmlMode mode);
+        public static extern void LinearFrac(int n, /* const */ [In] double* a, /* const */ [In] double* b, double scalea, double shifta, double scaleb, double shiftb, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCeil")]
-        public static extern void Ceil(int n, float* a, float* r);
+        public static extern void Ceil(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCeil")]
-        public static extern void Ceil(int n, double* a, double* r);
+        public static extern void Ceil(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCeil")]
-        public static extern void Ceil(int n, float* a, float* r, VmlMode mode);
+        public static extern void Ceil(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCeil")]
-        public static extern void Ceil(int n, double* a, double* r, VmlMode mode);
+        public static extern void Ceil(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsFloor")]
-        public static extern void Floor(int n, float* a, float* r);
+        public static extern void Floor(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdFloor")]
-        public static extern void Floor(int n, double* a, double* r);
+        public static extern void Floor(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsFloor")]
-        public static extern void Floor(int n, float* a, float* r, VmlMode mode);
+        public static extern void Floor(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdFloor")]
-        public static extern void Floor(int n, double* a, double* r, VmlMode mode);
+        public static extern void Floor(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsFrac")]
-        public static extern void Frac(int n, float* a, float* r);
+        public static extern void Frac(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdFrac")]
-        public static extern void Frac(int n, double* a, double* r);
+        public static extern void Frac(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsFrac")]
-        public static extern void Frac(int n, float* a, float* r, VmlMode mode);
+        public static extern void Frac(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdFrac")]
-        public static extern void Frac(int n, double* a, double* r, VmlMode mode);
+        public static extern void Frac(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsModf")]
-        public static extern void Modf(int n, float* a, float* r1, float* r2);
+        public static extern void Modf(int n, /* const */ [In] float* a, float* r1, float* r2);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdModf")]
-        public static extern void Modf(int n, double* a, double* r1, double* r2);
+        public static extern void Modf(int n, /* const */ [In] double* a, double* r1, double* r2);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsModf")]
-        public static extern void Modf(int n, float* a, float* r1, float* r2, VmlMode mode);
+        public static extern void Modf(int n, /* const */ [In] float* a, float* r1, float* r2, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdModf")]
-        public static extern void Modf(int n, double* a, double* r1, double* r2, VmlMode mode);
+        public static extern void Modf(int n, /* const */ [In] double* a, double* r1, double* r2, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsFmod")]
-        public static extern void Fmod(int n, float* a, float* b, float* r);
+        public static extern void Fmod(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdFmod")]
-        public static extern void Fmod(int n, double* a, double* b, double* r);
+        public static extern void Fmod(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsFmod")]
-        public static extern void Fmod(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void Fmod(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdFmod")]
-        public static extern void Fmod(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void Fmod(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsRemainder")]
-        public static extern void Remainder(int n, float* a, float* b, float* r);
+        public static extern void Remainder(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdRemainder")]
-        public static extern void Remainder(int n, double* a, double* b, double* r);
+        public static extern void Remainder(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsRemainder")]
-        public static extern void Remainder(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void Remainder(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdRemainder")]
-        public static extern void Remainder(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void Remainder(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsNextAfter")]
-        public static extern void NextAfter(int n, float* a, float* b, float* r);
+        public static extern void NextAfter(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdNextAfter")]
-        public static extern void NextAfter(int n, double* a, double* b, double* r);
+        public static extern void NextAfter(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsNextAfter")]
-        public static extern void NextAfter(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void NextAfter(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdNextAfter")]
-        public static extern void NextAfter(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void NextAfter(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCopySign")]
-        public static extern void CopySign(int n, float* a, float* b, float* r);
+        public static extern void CopySign(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCopySign")]
-        public static extern void CopySign(int n, double* a, double* b, double* r);
+        public static extern void CopySign(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCopySign")]
-        public static extern void CopySign(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void CopySign(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCopySign")]
-        public static extern void CopySign(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void CopySign(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsFdim")]
-        public static extern void Fdim(int n, float* a, float* b, float* r);
+        public static extern void Fdim(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdFdim")]
-        public static extern void Fdim(int n, double* a, double* b, double* r);
+        public static extern void Fdim(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsFdim")]
-        public static extern void Fdim(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void Fdim(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdFdim")]
-        public static extern void Fdim(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void Fdim(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsFmax")]
-        public static extern void Fmax(int n, float* a, float* b, float* r);
+        public static extern void Fmax(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdFmax")]
-        public static extern void Fmax(int n, double* a, double* b, double* r);
+        public static extern void Fmax(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsFmax")]
-        public static extern void Fmax(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void Fmax(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdFmax")]
-        public static extern void Fmax(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void Fmax(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsFmin")]
-        public static extern void Fmin(int n, float* a, float* b, float* r);
+        public static extern void Fmin(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdFmin")]
-        public static extern void Fmin(int n, double* a, double* b, double* r);
+        public static extern void Fmin(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsFmin")]
-        public static extern void Fmin(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void Fmin(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdFmin")]
-        public static extern void Fmin(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void Fmin(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsMaxMag")]
-        public static extern void MaxMag(int n, float* a, float* b, float* r);
+        public static extern void MaxMag(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdMaxMag")]
-        public static extern void MaxMag(int n, double* a, double* b, double* r);
+        public static extern void MaxMag(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsMaxMag")]
-        public static extern void MaxMag(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void MaxMag(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdMaxMag")]
-        public static extern void MaxMag(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void MaxMag(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsMinMag")]
-        public static extern void MinMag(int n, float* a, float* b, float* r);
+        public static extern void MinMag(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdMinMag")]
-        public static extern void MinMag(int n, double* a, double* b, double* r);
+        public static extern void MinMag(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsMinMag")]
-        public static extern void MinMag(int n, float* a, float* b, float* r, VmlMode mode);
+        public static extern void MinMag(int n, /* const */ [In] float* a, /* const */ [In] float* b, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdMinMag")]
-        public static extern void MinMag(int n, double* a, double* b, double* r, VmlMode mode);
+        public static extern void MinMag(int n, /* const */ [In] double* a, /* const */ [In] double* b, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsNearbyInt")]
-        public static extern void NearbyInt(int n, float* a, float* r);
+        public static extern void NearbyInt(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdNearbyInt")]
-        public static extern void NearbyInt(int n, double* a, double* r);
+        public static extern void NearbyInt(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsNearbyInt")]
-        public static extern void NearbyInt(int n, float* a, float* r, VmlMode mode);
+        public static extern void NearbyInt(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdNearbyInt")]
-        public static extern void NearbyInt(int n, double* a, double* r, VmlMode mode);
+        public static extern void NearbyInt(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsRint")]
-        public static extern void Rint(int n, float* a, float* r);
+        public static extern void Rint(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdRint")]
-        public static extern void Rint(int n, double* a, double* r);
+        public static extern void Rint(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsRint")]
-        public static extern void Rint(int n, float* a, float* r, VmlMode mode);
+        public static extern void Rint(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdRint")]
-        public static extern void Rint(int n, double* a, double* r, VmlMode mode);
+        public static extern void Rint(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsRound")]
-        public static extern void Round(int n, float* a, float* r);
+        public static extern void Round(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdRound")]
-        public static extern void Round(int n, double* a, double* r);
+        public static extern void Round(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsRound")]
-        public static extern void Round(int n, float* a, float* r, VmlMode mode);
+        public static extern void Round(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdRound")]
-        public static extern void Round(int n, double* a, double* r, VmlMode mode);
+        public static extern void Round(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsTrunc")]
-        public static extern void Trunc(int n, float* a, float* r);
+        public static extern void Trunc(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdTrunc")]
-        public static extern void Trunc(int n, double* a, double* r);
+        public static extern void Trunc(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsTrunc")]
-        public static extern void Trunc(int n, float* a, float* r, VmlMode mode);
+        public static extern void Trunc(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdTrunc")]
-        public static extern void Trunc(int n, double* a, double* r, VmlMode mode);
+        public static extern void Trunc(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsExpInt1")]
-        public static extern void ExpInt1(int n, float* a, float* r);
+        public static extern void ExpInt1(int n, /* const */ [In] float* a, float* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdExpInt1")]
-        public static extern void ExpInt1(int n, double* a, double* r);
+        public static extern void ExpInt1(int n, /* const */ [In] double* a, double* r);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsExpInt1")]
-        public static extern void ExpInt1(int n, float* a, float* r, VmlMode mode);
+        public static extern void ExpInt1(int n, /* const */ [In] float* a, float* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdExpInt1")]
-        public static extern void ExpInt1(int n, double* a, double* r, VmlMode mode);
+        public static extern void ExpInt1(int n, /* const */ [In] double* a, double* r, VmlMode mode);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAbsI")]
-        public static extern void AbsI(int n, float* a, int inca, float* r, int incr);
+        public static extern void AbsI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAbsI")]
-        public static extern void AbsI(int n, double* a, int inca, double* r, int incr);
+        public static extern void AbsI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAbsI")]
-        public static extern void AbsI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void AbsI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAbsI")]
-        public static extern void AbsI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void AbsI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAddI")]
-        public static extern void AddI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void AddI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAddI")]
-        public static extern void AddI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void AddI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAddI")]
-        public static extern void AddI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void AddI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAddI")]
-        public static extern void AddI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void AddI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSubI")]
-        public static extern void SubI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void SubI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSubI")]
-        public static extern void SubI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void SubI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSubI")]
-        public static extern void SubI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void SubI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSubI")]
-        public static extern void SubI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void SubI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsInvI")]
-        public static extern void InvI(int n, float* a, int inca, float* r, int incr);
+        public static extern void InvI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdInvI")]
-        public static extern void InvI(int n, double* a, int inca, double* r, int incr);
+        public static extern void InvI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsInvI")]
-        public static extern void InvI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void InvI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdInvI")]
-        public static extern void InvI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void InvI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSqrtI")]
-        public static extern void SqrtI(int n, float* a, int inca, float* r, int incr);
+        public static extern void SqrtI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSqrtI")]
-        public static extern void SqrtI(int n, double* a, int inca, double* r, int incr);
+        public static extern void SqrtI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSqrtI")]
-        public static extern void SqrtI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void SqrtI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSqrtI")]
-        public static extern void SqrtI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void SqrtI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsInvSqrtI")]
-        public static extern void InvSqrtI(int n, float* a, int inca, float* r, int incr);
+        public static extern void InvSqrtI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdInvSqrtI")]
-        public static extern void InvSqrtI(int n, double* a, int inca, double* r, int incr);
+        public static extern void InvSqrtI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsInvSqrtI")]
-        public static extern void InvSqrtI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void InvSqrtI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdInvSqrtI")]
-        public static extern void InvSqrtI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void InvSqrtI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCbrtI")]
-        public static extern void CbrtI(int n, float* a, int inca, float* r, int incr);
+        public static extern void CbrtI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCbrtI")]
-        public static extern void CbrtI(int n, double* a, int inca, double* r, int incr);
+        public static extern void CbrtI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCbrtI")]
-        public static extern void CbrtI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void CbrtI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCbrtI")]
-        public static extern void CbrtI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void CbrtI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsInvCbrtI")]
-        public static extern void InvCbrtI(int n, float* a, int inca, float* r, int incr);
+        public static extern void InvCbrtI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdInvCbrtI")]
-        public static extern void InvCbrtI(int n, double* a, int inca, double* r, int incr);
+        public static extern void InvCbrtI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsInvCbrtI")]
-        public static extern void InvCbrtI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void InvCbrtI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdInvCbrtI")]
-        public static extern void InvCbrtI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void InvCbrtI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSqrI")]
-        public static extern void SqrI(int n, float* a, int inca, float* r, int incr);
+        public static extern void SqrI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSqrI")]
-        public static extern void SqrI(int n, double* a, int inca, double* r, int incr);
+        public static extern void SqrI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSqrI")]
-        public static extern void SqrI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void SqrI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSqrI")]
-        public static extern void SqrI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void SqrI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsExpI")]
-        public static extern void ExpI(int n, float* a, int inca, float* r, int incr);
+        public static extern void ExpI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdExpI")]
-        public static extern void ExpI(int n, double* a, int inca, double* r, int incr);
+        public static extern void ExpI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsExpI")]
-        public static extern void ExpI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void ExpI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdExpI")]
-        public static extern void ExpI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void ExpI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsExp2I")]
-        public static extern void Exp2I(int n, float* a, int inca, float* r, int incr);
+        public static extern void Exp2I(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdExp2I")]
-        public static extern void Exp2I(int n, double* a, int inca, double* r, int incr);
+        public static extern void Exp2I(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsExp2I")]
-        public static extern void Exp2I(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void Exp2I(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdExp2I")]
-        public static extern void Exp2I(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void Exp2I(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsExp10I")]
-        public static extern void Exp10I(int n, float* a, int inca, float* r, int incr);
+        public static extern void Exp10I(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdExp10I")]
-        public static extern void Exp10I(int n, double* a, int inca, double* r, int incr);
+        public static extern void Exp10I(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsExp10I")]
-        public static extern void Exp10I(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void Exp10I(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdExp10I")]
-        public static extern void Exp10I(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void Exp10I(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsExpm1I")]
-        public static extern void Expm1I(int n, float* a, int inca, float* r, int incr);
+        public static extern void Expm1I(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdExpm1I")]
-        public static extern void Expm1I(int n, double* a, int inca, double* r, int incr);
+        public static extern void Expm1I(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsExpm1I")]
-        public static extern void Expm1I(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void Expm1I(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdExpm1I")]
-        public static extern void Expm1I(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void Expm1I(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsLnI")]
-        public static extern void LnI(int n, float* a, int inca, float* r, int incr);
+        public static extern void LnI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdLnI")]
-        public static extern void LnI(int n, double* a, int inca, double* r, int incr);
+        public static extern void LnI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsLnI")]
-        public static extern void LnI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void LnI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdLnI")]
-        public static extern void LnI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void LnI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsLog10I")]
-        public static extern void Log10I(int n, float* a, int inca, float* r, int incr);
+        public static extern void Log10I(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdLog10I")]
-        public static extern void Log10I(int n, double* a, int inca, double* r, int incr);
+        public static extern void Log10I(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsLog10I")]
-        public static extern void Log10I(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void Log10I(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdLog10I")]
-        public static extern void Log10I(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void Log10I(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsLog2I")]
-        public static extern void Log2I(int n, float* a, int inca, float* r, int incr);
+        public static extern void Log2I(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdLog2I")]
-        public static extern void Log2I(int n, double* a, int inca, double* r, int incr);
+        public static extern void Log2I(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsLog2I")]
-        public static extern void Log2I(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void Log2I(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdLog2I")]
-        public static extern void Log2I(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void Log2I(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsLog1pI")]
-        public static extern void Log1pI(int n, float* a, int inca, float* r, int incr);
+        public static extern void Log1pI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdLog1pI")]
-        public static extern void Log1pI(int n, double* a, int inca, double* r, int incr);
+        public static extern void Log1pI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsLog1pI")]
-        public static extern void Log1pI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void Log1pI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdLog1pI")]
-        public static extern void Log1pI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void Log1pI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsLogbI")]
-        public static extern void LogbI(int n, float* a, int inca, float* r, int incr);
+        public static extern void LogbI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdLogbI")]
-        public static extern void LogbI(int n, double* a, int inca, double* r, int incr);
+        public static extern void LogbI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsLogbI")]
-        public static extern void LogbI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void LogbI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdLogbI")]
-        public static extern void LogbI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void LogbI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCosI")]
-        public static extern void CosI(int n, float* a, int inca, float* r, int incr);
+        public static extern void CosI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCosI")]
-        public static extern void CosI(int n, double* a, int inca, double* r, int incr);
+        public static extern void CosI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCosI")]
-        public static extern void CosI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void CosI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCosI")]
-        public static extern void CosI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void CosI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSinI")]
-        public static extern void SinI(int n, float* a, int inca, float* r, int incr);
+        public static extern void SinI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSinI")]
-        public static extern void SinI(int n, double* a, int inca, double* r, int incr);
+        public static extern void SinI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSinI")]
-        public static extern void SinI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void SinI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSinI")]
-        public static extern void SinI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void SinI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsTanI")]
-        public static extern void TanI(int n, float* a, int inca, float* r, int incr);
+        public static extern void TanI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdTanI")]
-        public static extern void TanI(int n, double* a, int inca, double* r, int incr);
+        public static extern void TanI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsTanI")]
-        public static extern void TanI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void TanI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdTanI")]
-        public static extern void TanI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void TanI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCoshI")]
-        public static extern void CoshI(int n, float* a, int inca, float* r, int incr);
+        public static extern void CoshI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCoshI")]
-        public static extern void CoshI(int n, double* a, int inca, double* r, int incr);
+        public static extern void CoshI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCoshI")]
-        public static extern void CoshI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void CoshI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCoshI")]
-        public static extern void CoshI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void CoshI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCosdI")]
-        public static extern void CosdI(int n, float* a, int inca, float* r, int incr);
+        public static extern void CosdI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCosdI")]
-        public static extern void CosdI(int n, double* a, int inca, double* r, int incr);
+        public static extern void CosdI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCosdI")]
-        public static extern void CosdI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void CosdI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCosdI")]
-        public static extern void CosdI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void CosdI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCospiI")]
-        public static extern void CospiI(int n, float* a, int inca, float* r, int incr);
+        public static extern void CospiI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCospiI")]
-        public static extern void CospiI(int n, double* a, int inca, double* r, int incr);
+        public static extern void CospiI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCospiI")]
-        public static extern void CospiI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void CospiI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCospiI")]
-        public static extern void CospiI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void CospiI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSinhI")]
-        public static extern void SinhI(int n, float* a, int inca, float* r, int incr);
+        public static extern void SinhI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSinhI")]
-        public static extern void SinhI(int n, double* a, int inca, double* r, int incr);
+        public static extern void SinhI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSinhI")]
-        public static extern void SinhI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void SinhI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSinhI")]
-        public static extern void SinhI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void SinhI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSindI")]
-        public static extern void SindI(int n, float* a, int inca, float* r, int incr);
+        public static extern void SindI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSindI")]
-        public static extern void SindI(int n, double* a, int inca, double* r, int incr);
+        public static extern void SindI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSindI")]
-        public static extern void SindI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void SindI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSindI")]
-        public static extern void SindI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void SindI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSinpiI")]
-        public static extern void SinpiI(int n, float* a, int inca, float* r, int incr);
+        public static extern void SinpiI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSinpiI")]
-        public static extern void SinpiI(int n, double* a, int inca, double* r, int incr);
+        public static extern void SinpiI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSinpiI")]
-        public static extern void SinpiI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void SinpiI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSinpiI")]
-        public static extern void SinpiI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void SinpiI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsTanhI")]
-        public static extern void TanhI(int n, float* a, int inca, float* r, int incr);
+        public static extern void TanhI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdTanhI")]
-        public static extern void TanhI(int n, double* a, int inca, double* r, int incr);
+        public static extern void TanhI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsTanhI")]
-        public static extern void TanhI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void TanhI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdTanhI")]
-        public static extern void TanhI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void TanhI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsTandI")]
-        public static extern void TandI(int n, float* a, int inca, float* r, int incr);
+        public static extern void TandI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdTandI")]
-        public static extern void TandI(int n, double* a, int inca, double* r, int incr);
+        public static extern void TandI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsTandI")]
-        public static extern void TandI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void TandI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdTandI")]
-        public static extern void TandI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void TandI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsTanpiI")]
-        public static extern void TanpiI(int n, float* a, int inca, float* r, int incr);
+        public static extern void TanpiI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdTanpiI")]
-        public static extern void TanpiI(int n, double* a, int inca, double* r, int incr);
+        public static extern void TanpiI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsTanpiI")]
-        public static extern void TanpiI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void TanpiI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdTanpiI")]
-        public static extern void TanpiI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void TanpiI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAcosI")]
-        public static extern void AcosI(int n, float* a, int inca, float* r, int incr);
+        public static extern void AcosI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAcosI")]
-        public static extern void AcosI(int n, double* a, int inca, double* r, int incr);
+        public static extern void AcosI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAcosI")]
-        public static extern void AcosI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void AcosI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAcosI")]
-        public static extern void AcosI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void AcosI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAcospiI")]
-        public static extern void AcospiI(int n, float* a, int inca, float* r, int incr);
+        public static extern void AcospiI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAcospiI")]
-        public static extern void AcospiI(int n, double* a, int inca, double* r, int incr);
+        public static extern void AcospiI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAcospiI")]
-        public static extern void AcospiI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void AcospiI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAcospiI")]
-        public static extern void AcospiI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void AcospiI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAsinI")]
-        public static extern void AsinI(int n, float* a, int inca, float* r, int incr);
+        public static extern void AsinI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAsinI")]
-        public static extern void AsinI(int n, double* a, int inca, double* r, int incr);
+        public static extern void AsinI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAsinI")]
-        public static extern void AsinI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void AsinI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAsinI")]
-        public static extern void AsinI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void AsinI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAsinpiI")]
-        public static extern void AsinpiI(int n, float* a, int inca, float* r, int incr);
+        public static extern void AsinpiI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAsinpiI")]
-        public static extern void AsinpiI(int n, double* a, int inca, double* r, int incr);
+        public static extern void AsinpiI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAsinpiI")]
-        public static extern void AsinpiI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void AsinpiI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAsinpiI")]
-        public static extern void AsinpiI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void AsinpiI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAtanI")]
-        public static extern void AtanI(int n, float* a, int inca, float* r, int incr);
+        public static extern void AtanI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAtanI")]
-        public static extern void AtanI(int n, double* a, int inca, double* r, int incr);
+        public static extern void AtanI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAtanI")]
-        public static extern void AtanI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void AtanI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAtanI")]
-        public static extern void AtanI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void AtanI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAtanpiI")]
-        public static extern void AtanpiI(int n, float* a, int inca, float* r, int incr);
+        public static extern void AtanpiI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAtanpiI")]
-        public static extern void AtanpiI(int n, double* a, int inca, double* r, int incr);
+        public static extern void AtanpiI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAtanpiI")]
-        public static extern void AtanpiI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void AtanpiI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAtanpiI")]
-        public static extern void AtanpiI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void AtanpiI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAcoshI")]
-        public static extern void AcoshI(int n, float* a, int inca, float* r, int incr);
+        public static extern void AcoshI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAcoshI")]
-        public static extern void AcoshI(int n, double* a, int inca, double* r, int incr);
+        public static extern void AcoshI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAcoshI")]
-        public static extern void AcoshI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void AcoshI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAcoshI")]
-        public static extern void AcoshI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void AcoshI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAsinhI")]
-        public static extern void AsinhI(int n, float* a, int inca, float* r, int incr);
+        public static extern void AsinhI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAsinhI")]
-        public static extern void AsinhI(int n, double* a, int inca, double* r, int incr);
+        public static extern void AsinhI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAsinhI")]
-        public static extern void AsinhI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void AsinhI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAsinhI")]
-        public static extern void AsinhI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void AsinhI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAtanhI")]
-        public static extern void AtanhI(int n, float* a, int inca, float* r, int incr);
+        public static extern void AtanhI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAtanhI")]
-        public static extern void AtanhI(int n, double* a, int inca, double* r, int incr);
+        public static extern void AtanhI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAtanhI")]
-        public static extern void AtanhI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void AtanhI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAtanhI")]
-        public static extern void AtanhI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void AtanhI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsErfI")]
-        public static extern void ErfI(int n, float* a, int inca, float* r, int incr);
+        public static extern void ErfI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdErfI")]
-        public static extern void ErfI(int n, double* a, int inca, double* r, int incr);
+        public static extern void ErfI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsErfI")]
-        public static extern void ErfI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void ErfI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdErfI")]
-        public static extern void ErfI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void ErfI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsErfInvI")]
-        public static extern void ErfInvI(int n, float* a, int inca, float* r, int incr);
+        public static extern void ErfInvI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdErfInvI")]
-        public static extern void ErfInvI(int n, double* a, int inca, double* r, int incr);
+        public static extern void ErfInvI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsErfInvI")]
-        public static extern void ErfInvI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void ErfInvI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdErfInvI")]
-        public static extern void ErfInvI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void ErfInvI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsHypotI")]
-        public static extern void HypotI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void HypotI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdHypotI")]
-        public static extern void HypotI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void HypotI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsHypotI")]
-        public static extern void HypotI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void HypotI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdHypotI")]
-        public static extern void HypotI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void HypotI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsErfcI")]
-        public static extern void ErfcI(int n, float* a, int inca, float* r, int incr);
+        public static extern void ErfcI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdErfcI")]
-        public static extern void ErfcI(int n, double* a, int inca, double* r, int incr);
+        public static extern void ErfcI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsErfcI")]
-        public static extern void ErfcI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void ErfcI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdErfcI")]
-        public static extern void ErfcI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void ErfcI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsErfcInvI")]
-        public static extern void ErfcInvI(int n, float* a, int inca, float* r, int incr);
+        public static extern void ErfcInvI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdErfcInvI")]
-        public static extern void ErfcInvI(int n, double* a, int inca, double* r, int incr);
+        public static extern void ErfcInvI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsErfcInvI")]
-        public static extern void ErfcInvI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void ErfcInvI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdErfcInvI")]
-        public static extern void ErfcInvI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void ErfcInvI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCdfNormI")]
-        public static extern void CdfNormI(int n, float* a, int inca, float* r, int incr);
+        public static extern void CdfNormI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCdfNormI")]
-        public static extern void CdfNormI(int n, double* a, int inca, double* r, int incr);
+        public static extern void CdfNormI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCdfNormI")]
-        public static extern void CdfNormI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void CdfNormI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCdfNormI")]
-        public static extern void CdfNormI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void CdfNormI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCdfNormInvI")]
-        public static extern void CdfNormInvI(int n, float* a, int inca, float* r, int incr);
+        public static extern void CdfNormInvI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCdfNormInvI")]
-        public static extern void CdfNormInvI(int n, double* a, int inca, double* r, int incr);
+        public static extern void CdfNormInvI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCdfNormInvI")]
-        public static extern void CdfNormInvI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void CdfNormInvI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCdfNormInvI")]
-        public static extern void CdfNormInvI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void CdfNormInvI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsLGammaI")]
-        public static extern void LGammaI(int n, float* a, int inca, float* r, int incr);
+        public static extern void LGammaI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdLGammaI")]
-        public static extern void LGammaI(int n, double* a, int inca, double* r, int incr);
+        public static extern void LGammaI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsLGammaI")]
-        public static extern void LGammaI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void LGammaI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdLGammaI")]
-        public static extern void LGammaI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void LGammaI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsTGammaI")]
-        public static extern void TGammaI(int n, float* a, int inca, float* r, int incr);
+        public static extern void TGammaI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdTGammaI")]
-        public static extern void TGammaI(int n, double* a, int inca, double* r, int incr);
+        public static extern void TGammaI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsTGammaI")]
-        public static extern void TGammaI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void TGammaI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdTGammaI")]
-        public static extern void TGammaI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void TGammaI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAtan2I")]
-        public static extern void Atan2I(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void Atan2I(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAtan2I")]
-        public static extern void Atan2I(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void Atan2I(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAtan2I")]
-        public static extern void Atan2I(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void Atan2I(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAtan2I")]
-        public static extern void Atan2I(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void Atan2I(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsAtan2piI")]
-        public static extern void Atan2piI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void Atan2piI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdAtan2piI")]
-        public static extern void Atan2piI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void Atan2piI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsAtan2piI")]
-        public static extern void Atan2piI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void Atan2piI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdAtan2piI")]
-        public static extern void Atan2piI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void Atan2piI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsMulI")]
-        public static extern void MulI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void MulI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdMulI")]
-        public static extern void MulI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void MulI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsMulI")]
-        public static extern void MulI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void MulI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdMulI")]
-        public static extern void MulI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void MulI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsDivI")]
-        public static extern void DivI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void DivI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdDivI")]
-        public static extern void DivI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void DivI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsDivI")]
-        public static extern void DivI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void DivI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdDivI")]
-        public static extern void DivI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void DivI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsFdimI")]
-        public static extern void FdimI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void FdimI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdFdimI")]
-        public static extern void FdimI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void FdimI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsFdimI")]
-        public static extern void FdimI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void FdimI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdFdimI")]
-        public static extern void FdimI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void FdimI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsFmodI")]
-        public static extern void FmodI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void FmodI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdFmodI")]
-        public static extern void FmodI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void FmodI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsFmodI")]
-        public static extern void FmodI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void FmodI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdFmodI")]
-        public static extern void FmodI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void FmodI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsFmaxI")]
-        public static extern void FmaxI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void FmaxI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdFmaxI")]
-        public static extern void FmaxI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void FmaxI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsFmaxI")]
-        public static extern void FmaxI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void FmaxI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdFmaxI")]
-        public static extern void FmaxI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void FmaxI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsFminI")]
-        public static extern void FminI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void FminI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdFminI")]
-        public static extern void FminI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void FminI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
 
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsFminI")]
-        public static extern void FminI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void FminI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdFminI")]
-        public static extern void FminI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void FminI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsPowI")]
-        public static extern void PowI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void PowI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdPowI")]
-        public static extern void PowI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void PowI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsPowI")]
-        public static extern void PowI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void PowI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdPowI")]
-        public static extern void PowI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void PowI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsPowrI")]
-        public static extern void PowrI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void PowrI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdPowrI")]
-        public static extern void PowrI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void PowrI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsPowrI")]
-        public static extern void PowrI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void PowrI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdPowrI")]
-        public static extern void PowrI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void PowrI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsPow3o2I")]
-        public static extern void Pow3o2I(int n, float* a, int inca, float* r, int incr);
+        public static extern void Pow3o2I(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdPow3o2I")]
-        public static extern void Pow3o2I(int n, double* a, int inca, double* r, int incr);
+        public static extern void Pow3o2I(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsPow3o2I")]
-        public static extern void Pow3o2I(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void Pow3o2I(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdPow3o2I")]
-        public static extern void Pow3o2I(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void Pow3o2I(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsPow2o3I")]
-        public static extern void Pow2o3I(int n, float* a, int inca, float* r, int incr);
+        public static extern void Pow2o3I(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdPow2o3I")]
-        public static extern void Pow2o3I(int n, double* a, int inca, double* r, int incr);
+        public static extern void Pow2o3I(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsPow2o3I")]
-        public static extern void Pow2o3I(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void Pow2o3I(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdPow2o3I")]
-        public static extern void Pow2o3I(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void Pow2o3I(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsPowxI")]
-        public static extern void PowxI(int n, float* a, int inca, float b, float* r, int incr);
+        public static extern void PowxI(int n, /* const */ [In] float* a, int inca, float b, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdPowxI")]
-        public static extern void PowxI(int n, double* a, int inca, double b, double* r, int incr);
+        public static extern void PowxI(int n, /* const */ [In] double* a, int inca, double b, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsPowxI")]
-        public static extern void PowxI(int n, float* a, int inca, float b, float* r, int incr, VmlMode mode);
+        public static extern void PowxI(int n, /* const */ [In] float* a, int inca, float b, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdPowxI")]
-        public static extern void PowxI(int n, double* a, int inca, double b, double* r, int incr, VmlMode mode);
+        public static extern void PowxI(int n, /* const */ [In] double* a, int inca, double b, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsSinCosI")]
-        public static extern void SinCosI(int n, float* a, int inca, float* r1, int incr1, float* r2, int incr2);
+        public static extern void SinCosI(int n, /* const */ [In] float* a, int inca, float* r1, int incr1, float* r2, int incr2);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdSinCosI")]
-        public static extern void SinCosI(int n, double* a, int inca, double* r1, int incr1, double* r2, int incr2);
+        public static extern void SinCosI(int n, /* const */ [In] double* a, int inca, double* r1, int incr1, double* r2, int incr2);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsSinCosI")]
-        public static extern void SinCosI(int n, float* a, int inca, float* r1, int incr1, float* r2, int incr2, VmlMode mode);
+        public static extern void SinCosI(int n, /* const */ [In] float* a, int inca, float* r1, int incr1, float* r2, int incr2, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdSinCosI")]
-        public static extern void SinCosI(int n, double* a, int inca, double* r1, int incr1, double* r2, int incr2, VmlMode mode);
+        public static extern void SinCosI(int n, /* const */ [In] double* a, int inca, double* r1, int incr1, double* r2, int incr2, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsLinearFracI")]
-        public static extern void LinearFracI(int n, float* a, int inca, float* b, int incb, float scalea, float shifta, float scaleb, float shiftb, float* r, int incr);
+        public static extern void LinearFracI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float scalea, float shifta, float scaleb, float shiftb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdLinearFracI")]
-        public static extern void LinearFracI(int n, double* a, int inca, double* b, int incb, double scalea, double shifta, double scaleb, double shiftb, double* r, int incr);
+        public static extern void LinearFracI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double scalea, double shifta, double scaleb, double shiftb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsLinearFracI")]
-        public static extern void LinearFracI(int n, float* a, int inca, float* b, int incb, float scalea, float shifta, float scaleb, float shiftb, float* r, int incr, VmlMode mode);
+        public static extern void LinearFracI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float scalea, float shifta, float scaleb, float shiftb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdLinearFracI")]
-        public static extern void LinearFracI(int n, double* a, int inca, double* b, int incb, double scalea, double shifta, double scaleb, double shiftb, double* r, int incr, VmlMode mode);
+        public static extern void LinearFracI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double scalea, double shifta, double scaleb, double shiftb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCeilI")]
-        public static extern void CeilI(int n, float* a, int inca, float* r, int incr);
+        public static extern void CeilI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCeilI")]
-        public static extern void CeilI(int n, double* a, int inca, double* r, int incr);
+        public static extern void CeilI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCeilI")]
-        public static extern void CeilI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void CeilI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCeilI")]
-        public static extern void CeilI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void CeilI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsFloorI")]
-        public static extern void FloorI(int n, float* a, int inca, float* r, int incr);
+        public static extern void FloorI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdFloorI")]
-        public static extern void FloorI(int n, double* a, int inca, double* r, int incr);
+        public static extern void FloorI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsFloorI")]
-        public static extern void FloorI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void FloorI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdFloorI")]
-        public static extern void FloorI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void FloorI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsFracI")]
-        public static extern void FracI(int n, float* a, int inca, float* r, int incr);
+        public static extern void FracI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdFracI")]
-        public static extern void FracI(int n, double* a, int inca, double* r, int incr);
+        public static extern void FracI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsFracI")]
-        public static extern void FracI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void FracI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdFracI")]
-        public static extern void FracI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void FracI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsModfI")]
-        public static extern void ModfI(int n, float* a, int inca, float* r1, int incr1, float* r2, int incr2);
+        public static extern void ModfI(int n, /* const */ [In] float* a, int inca, float* r1, int incr1, float* r2, int incr2);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdModfI")]
-        public static extern void ModfI(int n, double* a, int inca, double* r1, int incr1, double* r2, int incr2);
+        public static extern void ModfI(int n, /* const */ [In] double* a, int inca, double* r1, int incr1, double* r2, int incr2);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsModfI")]
-        public static extern void ModfI(int n, float* a, int inca, float* r1, int incr1, float* r2, int incr2, VmlMode mode);
+        public static extern void ModfI(int n, /* const */ [In] float* a, int inca, float* r1, int incr1, float* r2, int incr2, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdModfI")]
-        public static extern void ModfI(int n, double* a, int inca, double* r1, int incr1, double* r2, int incr2, VmlMode mode);
+        public static extern void ModfI(int n, /* const */ [In] double* a, int inca, double* r1, int incr1, double* r2, int incr2, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsNearbyIntI")]
-        public static extern void NearbyIntI(int n, float* a, int inca, float* r, int incr);
+        public static extern void NearbyIntI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdNearbyIntI")]
-        public static extern void NearbyIntI(int n, double* a, int inca, double* r, int incr);
+        public static extern void NearbyIntI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsNearbyIntI")]
-        public static extern void NearbyIntI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void NearbyIntI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdNearbyIntI")]
-        public static extern void NearbyIntI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void NearbyIntI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsNextAfterI")]
-        public static extern void NextAfterI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void NextAfterI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdNextAfterI")]
-        public static extern void NextAfterI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void NextAfterI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsNextAfterI")]
-        public static extern void NextAfterI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void NextAfterI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdNextAfterI")]
-        public static extern void NextAfterI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void NextAfterI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsMinMagI")]
-        public static extern void MinMagI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void MinMagI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdMinMagI")]
-        public static extern void MinMagI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void MinMagI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsMinMagI")]
-        public static extern void MinMagI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void MinMagI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdMinMagI")]
-        public static extern void MinMagI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void MinMagI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsMaxMagI")]
-        public static extern void MaxMagI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void MaxMagI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdMaxMagI")]
-        public static extern void MaxMagI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void MaxMagI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsMaxMagI")]
-        public static extern void MaxMagI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void MaxMagI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdMaxMagI")]
-        public static extern void MaxMagI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void MaxMagI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsRintI")]
-        public static extern void RintI(int n, float* a, int inca, float* r, int incr);
+        public static extern void RintI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdRintI")]
-        public static extern void RintI(int n, double* a, int inca, double* r, int incr);
+        public static extern void RintI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsRintI")]
-        public static extern void RintI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void RintI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdRintI")]
-        public static extern void RintI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void RintI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsRoundI")]
-        public static extern void RoundI(int n, float* a, int inca, float* r, int incr);
+        public static extern void RoundI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdRoundI")]
-        public static extern void RoundI(int n, double* a, int inca, double* r, int incr);
+        public static extern void RoundI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsRoundI")]
-        public static extern void RoundI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void RoundI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdRoundI")]
-        public static extern void RoundI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void RoundI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsTruncI")]
-        public static extern void TruncI(int n, float* a, int inca, float* r, int incr);
+        public static extern void TruncI(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdTruncI")]
-        public static extern void TruncI(int n, double* a, int inca, double* r, int incr);
+        public static extern void TruncI(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsTruncI")]
-        public static extern void TruncI(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void TruncI(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdTruncI")]
-        public static extern void TruncI(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void TruncI(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsExpInt1I")]
-        public static extern void ExpInt1I(int n, float* a, int inca, float* r, int incr);
+        public static extern void ExpInt1I(int n, /* const */ [In] float* a, int inca, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdExpInt1I")]
-        public static extern void ExpInt1I(int n, double* a, int inca, double* r, int incr);
+        public static extern void ExpInt1I(int n, /* const */ [In] double* a, int inca, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsExpInt1I")]
-        public static extern void ExpInt1I(int n, float* a, int inca, float* r, int incr, VmlMode mode);
+        public static extern void ExpInt1I(int n, /* const */ [In] float* a, int inca, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdExpInt1I")]
-        public static extern void ExpInt1I(int n, double* a, int inca, double* r, int incr, VmlMode mode);
+        public static extern void ExpInt1I(int n, /* const */ [In] double* a, int inca, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsCopySignI")]
-        public static extern void CopySignI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void CopySignI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdCopySignI")]
-        public static extern void CopySignI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void CopySignI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsCopySignI")]
-        public static extern void CopySignI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void CopySignI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdCopySignI")]
-        public static extern void CopySignI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void CopySignI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsRemainderI")]
-        public static extern void RemainderI(int n, float* a, int inca, float* b, int incb, float* r, int incr);
+        public static extern void RemainderI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdRemainderI")]
-        public static extern void RemainderI(int n, double* a, int inca, double* b, int incb, double* r, int incr);
+        public static extern void RemainderI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmsRemainderI")]
-        public static extern void RemainderI(int n, float* a, int inca, float* b, int incb, float* r, int incr, VmlMode mode);
+        public static extern void RemainderI(int n, /* const */ [In] float* a, int inca, /* const */ [In] float* b, int incb, float* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vmdRemainderI")]
-        public static extern void RemainderI(int n, double* a, int inca, double* b, int incb, double* r, int incr, VmlMode mode);
+        public static extern void RemainderI(int n, /* const */ [In] double* a, int inca, /* const */ [In] double* b, int incb, double* r, int incr, VmlMode mode);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsPackI")]
-        public static extern void PackI(int n, float* a, int incra, float* y);
+        public static extern void PackI(int n, /* const */ [In] float* a, int incra, float* y);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdPackI")]
-        public static extern void PackI(int n, double* a, int incra, double* y);
+        public static extern void PackI(int n, /* const */ [In] double* a, int incra, double* y);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsPackV")]
-        public static extern void PackV(int n, float* a, int* ia, float* y);
+        public static extern void PackV(int n, /* const */ [In] float* a, int* ia, float* y);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdPackV")]
-        public static extern void PackV(int n, double* a, int* ia, double* y);
+        public static extern void PackV(int n, /* const */ [In] double* a, int* ia, double* y);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsPackM")]
-        public static extern void PackM(int n, float* a, int* ma, float* y);
+        public static extern void PackM(int n, /* const */ [In] float* a, int* ma, float* y);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdPackM")]
-        public static extern void PackM(int n, double* a, int* ma, double* y);
+        public static extern void PackM(int n, /* const */ [In] double* a, int* ma, double* y);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsUnpackI")]
-        public static extern void UnpackI(int n, float* a, float* y, int incry);
+        public static extern void UnpackI(int n, /* const */ [In] float* a, float* y, int incry);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdUnpackI")]
-        public static extern void UnpackI(int n, double* a, double* y, int incry);
+        public static extern void UnpackI(int n, /* const */ [In] double* a, double* y, int incry);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsUnpackV")]
-        public static extern void UnpackV(int n, float* a, float* y, int* iy);
+        public static extern void UnpackV(int n, /* const */ [In] float* a, float* y, int* iy);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdUnpackV")]
-        public static extern void UnpackV(int n, double* a, double* y, int* iy);
+        public static extern void UnpackV(int n, /* const */ [In] double* a, double* y, int* iy);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vsUnpackM")]
-        public static extern void UnpackM(int n, float* a, float* y, int* my);
+        public static extern void UnpackM(int n, /* const */ [In] float* a, float* y, int* my);
         [DllImport(MKL.DLL, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "vdUnpackM")]
-        public static extern void UnpackM(int n, double* a, double* y, int* my);
+        public static extern void UnpackM(int n, /* const */ [In] double* a, double* y, int* my);
     }
 
     // These are not unsafe


### PR DESCRIPTION
This addresses a suggestion from #14. I have gone through header files to find pointer arguments marked `const X*` and then marked them as `[In]` in our P/Invoke definitions. `[In]` doesn’t have any effect on pointers (can be used for array marshalling for example) but its semantics fit this use case. (Alternatives: invent our own attribute, use special parameter names)

The code generation was changed to check for the attribute when generating span wrapper. `[In]` arguments will now use `ReadOnlySpan` instead of `Span`. The attribute is stripped from the generated wrappers.

(Some small non-functional improvements on the code generator were performed in the first commit as well)