### PR TITLE
Fix varying parameters used for inferred length

### DIFF
--- a/MKL.NET.WrapperGenerator.Tests/GeneratorTest.cs
+++ b/MKL.NET.WrapperGenerator.Tests/GeneratorTest.cs
@@ -49,7 +49,10 @@ public static partial class BlasOption2
 
         generatorResult.Generator.Should().BeSameAs(generator);
         generatorResult.Diagnostics.Should().BeEmpty();
-        generatorResult.GeneratedSources.Should().HaveCount(1);
+        generatorResult.GeneratedSources.Should().ContainSingle()
+            .Which.SourceText.ToString().Should().Contain(
+                "///<remarks>" +
+                "This version infers the length parameter <c>N</c> from <paramref name=\"A\" />'s length.</remarks>");
         generatorResult.Exception.Should().BeNull();
     }
 

--- a/MKL.NET.WrapperGenerator/WrapperGenerator.cs
+++ b/MKL.NET.WrapperGenerator/WrapperGenerator.cs
@@ -36,10 +36,10 @@ public class WrapperGenerator : ISourceGenerator
         return candidates[0];
     }
 
-    private static (ISet<ParameterSyntax> changed, ParameterListSyntax newList)
+    private static (IList<ParameterSyntax> changed, ParameterListSyntax newList)
     TransformParameters(MethodDeclarationSyntax mds, Func<ParameterSyntax, ParameterSyntax?> f)
     {
-        var changed = mds.ParameterList.Parameters.Select(ps => f(ps) is null ? null : ps).Where(ps => ps != null).ToImmutableHashSet();
+        var changed = mds.ParameterList.Parameters.Select(ps => f(ps) is null ? null : ps).Where(ps => ps != null).ToImmutableList();
         var newList = SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(mds.ParameterList.Parameters.Select(ps => f(ps) ?? ps)));
 
         return (changed!, newList);
@@ -57,7 +57,7 @@ public class WrapperGenerator : ISourceGenerator
 
     void WriterTransformedMethod(
         MethodDeclarationSyntax mds, ClassDeclarationSyntax nativeCds,
-        (ISet<ParameterSyntax> changed, ParameterListSyntax newList) transformation, StringBuilder sb,
+        (IList<ParameterSyntax> changed, ParameterListSyntax newList) transformation, StringBuilder sb,
         AdditionalTransformation trafo)
     {
         (ParameterSyntax lengthParam, string takeLengthFrom)? lengthOptions = null;


### PR DESCRIPTION
The source generator creates overloads without length parameters like `n`. It does so by using the first transformed pointer argument's length.

However, due to the use of a hash set for the transformed arguments, whose order is not deterministic, the parameter that's used can vary in each build.

Apart from the parameter changing from version to version, unfortunately it also means that the reference assembly can use a different parameter than an assembly for a specific runtime identifier.

Typically, when all arguments have the same length this does not matter, and one could argue it's bad style to use this overload for arguments of varying length, but the documentation and code specifying a certain logic and then executing a different one should be considered a bug.

This fix switches the hash set to a list and adds a test. It leaves the existing logic of first argument.

If you think it'd make more sense to switch to the last argument (which is the result typically) we can also change that.
